### PR TITLE
DE-2142

### DIFF
--- a/docs/discrete/models/download_model.md
+++ b/docs/discrete/models/download_model.md
@@ -1,0 +1,62 @@
+# Download the Model
+
+Download the model from EdgeFirst Studio into the device.  There are two methods for downloading the model.  The first method is to download the model from EdgeFirst Studio and then SCP the model file to the device.  The second method is to use the EdgeFirst Client to download the model directly in the device.
+
+=== "Download using SCP"
+
+    As mentioned under the [Training Outcomes](../../models/modelpack/training.md#training-outcomes) section, the trained models can be downloaded by clicking the "View Additional Details" button on the training session card in EdgeFirst Studio. 
+
+    <figure markdown="span">
+    ![Training Session Attributes](../../models/assets/training/training-session-attributes.jpg){ align=center }
+    <figcaption>Training Session Attributes</figcaption>
+    </figure>
+
+    This will open the session details and the models are listed under the "Artifacts" tab as shown below.  Click on the downward arrow indicated in red to download the models to your PC.  In this example, you will be deploying the TFLite model in the device.
+
+    | Session Details                                                | Artifacts                                                                     |
+    |----------------------------------------------------------------|-------------------------------------------------------------------------------|
+    | ![session](../../models/assets/training/vision-session-details.jpg) | ![artifacts](../../models/assets/training/vision-session-artifacts.jpg) | 
+
+    Once the model is downloaded in your PC, you can [SCP](../../platforms/ssh.md#secure-copy) the model to the device by using this command template.
+
+    ```shell
+    scp <path to the downloaded TFLite model> <destination path>
+    ```
+
+    An example command is shown below.
+
+    ```shell
+    scp modelpack.tflite torizon@verdin-imx8mp-15140753:~
+    ```
+
+=== "Download using EdgeFirst Client"
+
+    This method expects you to have already connected to the device via [SSH](../../platforms/ssh.md).  The [EdgeFirst Client](../../perception/studio.md) can be installed via `pip3 install edgefirst-client`.  You can verify the installation with the client version command.
+
+    ```shell
+    $ edgefirst-client version
+    EdgeFirst Studio Server: 3.7.8-a50429e Client: 1.3.3
+    ```
+
+    Next login to EdgeFirst Studio with the command.
+
+    ```shell
+    $ edgefirst-client login
+    Username: user
+    Password: ****
+    ```
+
+    You can download the model on the device using the `download-artifact` command as shown below.
+
+    ```shell
+    edgefirst-client download-artifact <session ID> <model name>
+    ```
+
+    For example `edgefirst-client download-artifact 3928 'Coffee Cup Detection-t-f58.tflite'`. This command will download to the current working directory.
+
+    The `download-artifact` expects three arguments.
+
+    * session ID: Pass the trainer or validation integer session ID associated with the models.
+    * model name: Pass the specific model that will be downloaded to the device.  Usually this is `mymodel.tflite`.
+
+    You can find more information on using the [EdgeFirst Client](../../perception/studio.md) in the command line.

--- a/docs/models/modelpack/deployment/evk.md
+++ b/docs/models/modelpack/deployment/evk.md
@@ -25,6 +25,8 @@ source venv/bin/activate
 pip3 install edgefirst
 ```
 
+{% include-markdown "discrete/models/download_model.md" %}
+
 ## Usage
 
 Once installed, the applications can be launched using the `edgefirst` launcher which handles running the various [services](../../../perception/launcher.md#services).  The applications can also be run directly, for example `edgefirst-camera` to run the camera service.  The launcher is an optional but convenient way to run all the applications in "user-mode" in contrast to having the middleware integrated into the system as "system-mode" where the applications will be managed by systemd.
@@ -52,3 +54,11 @@ If testing a model trained using a few images collected on a phone you'll notice
 You can also access the MCAP recordings from the working directory where the `edgefirst live` command was run.
 
 Once you have your MCAP download to your PC you may upload it to EdgeFirst Studio to annotate and further train your model.  Uploading MCAP recordings is done through the [Snapshot Dashboard](../../../studio/snapshots.md#upload-from-mcap-file).
+
+## Next Steps
+
+In this tutorial, you have fetched the trained and validated model from EdgeFirst Studio, copied the model to the EVK and ran the model live using the EdgeFirst Live application and the EVK's camera. 
+
+See our [developer guide](../../../perception/dev/examples/model.md) for examples to query the model outputs using Rust or Python.
+
+For more examples on deploying ModelPack in other platforms, see [Model Deployment](../../tutorials/deployment.md).

--- a/docs/models/modelpack/deployment/maivin.md
+++ b/docs/models/modelpack/deployment/maivin.md
@@ -11,67 +11,7 @@ This guide will showcase two methods of deploying the model.
 1. [Live View (Segmentation App)](#live-view-segmentation-app): Displays the live camera feed using the default model provided.
 2. [MCAP Recording](#record-mcap): Allows control of the recording options and provides download file options to replay the recording.
 
-## Download the Model
-
-First download the model from EdgeFirst Studio into the Maivin Platform.  There are two methods for downloading the model.  The first method is to download the model from EdgeFirst Studio and then SCP the model file to the Maivin Platform.  The second method is to use the EdgeFirst Client to download the model directly in the device.
-
-### Download and SCP
-
-As mentioned under the [Training Outcomes](../training.md#training-outcomes) section, the trained models can be downloaded by clicking the "View Additional Details" button on the training session card in EdgeFirst Studio. 
-
-<figure markdown="span">
-![Training Session Attributes](../../assets/training/training-session-attributes.jpg){ align=center }
-<figcaption>Training Session Attributes</figcaption>
-</figure>
-
-This will open the session details and the models are listed under the "Artifacts" tab as shown below.  Click on the downward arrow indicated in red to download the models to your PC.  In this example, you will be deploying the TFLite model in the Maivin.
-
-| Session Details                                                | Artifacts                                                                     |
-|----------------------------------------------------------------|-------------------------------------------------------------------------------|
-| ![session](../../assets/training/vision-session-details.jpg) | ![artifacts](../../assets/training/vision-session-artifacts.jpg) | 
-
-Once the model is downloaded in your PC, you can [SCP](../../../platforms/ssh.md#secure-copy) the model to the Maivin by using this command template.
-
-```shell
-scp <path to the downloaded TFLite model> <destination path>
-```
-
-An example command is shown below.
-
-```shell
-scp modelpack.tflite torizon@verdin-imx8mp-15140753:~
-```
-
-### Download using the Client
-
-This method expects you to have already connected to the Maivin via [SSH](../../../platforms/ssh.md).  The [EdgeFirst Client](../../../perception/studio.md) can be installed via `pip3 install edgefirst-client`.  You can verify the installation with the client version command.
-
-```shell
-$ edgefirst-client version
-EdgeFirst Studio Server: 3.7.8-a50429e Client: 1.3.3
-```
-
-Next login to the client with the command.
-
-```shell
-$ edgefirst-client login
-Username: user
-Password: ****
-```
-
-You can download the model on the device using the `download-artifact` command as shown below.
-
-```shell
-edgefirst-client download-artifact <session ID> <model name>
-```
-
-The `download-artifact` expects three arguments.
-
-* session ID: Pass the integer trainer or validation session ID associated with the models.
-* model name: Pass the specific model that will be downloaded to the device.  Usually this is `mymodel.tflite`.
-* download path (optional): Specify the path to download the model.  If not provided, it will download to the current working directory.
-
-You can find more information on using the [EdgeFirst Client](../../../perception/studio.md) in the command line.
+{% include-markdown "discrete/models/download_model.md" %}
 
 ## Visit the Web UI Service
 
@@ -173,10 +113,7 @@ This will run inference on the model specified to generate segmentation masks on
 <figcaption>Sample 1</figcaption>
 </figure>
 
-Now that the model has been updated, you can make new recordings using the model's inference and then visualizing the recording using Foxglove Studio.
-
-{% include-markdown "discrete/datasets/recording_mcap_on_device.md" %}
-{% include-markdown "discrete/datasets/downloading_mcap_from_device.md" %}
+Now that the model has been updated, you can [make new recordings](../../../platforms/recording.md#record-mcap) using the model's inference and then [visualize the recording using Foxglove Studio](../../../platforms/foxglove.md).
 
 ## Inference Visualization in Foxglove
 Once the MCAP recording has been downloaded, you can use Foxglove Studio to see the playback of MCAP recordings and the model inference.  The following preview is a frame from the MCAP with the model inference masks overlaid on top of the video. 
@@ -191,5 +128,7 @@ More information on the MCAP playback is provided in [Foxglove Studio](../../../
 ## Next Steps
 
 In this tutorial, you have fetched the trained and validated model from EdgeFirst Studio, copied the model in the Maivin, configured the Maivin model services, and ran inference on the model in the device.  You have seen the model running live using the Maivin's camera and ran a Maivin MCAP recording to capture the model inference in the frames that can be visualized using Foxglove Studio. 
+
+See our [developer guide](../../../perception/dev/examples/model.md) for examples to query the model outputs using Rust or Python.
 
 For more examples on deploying ModelPack in other platforms, see [Model Deployment](../../tutorials/deployment.md).


### PR DESCRIPTION
1. Made download_model.md instructions as a discrete doc to make it appear under the EVK and Maivin deployments as a prerequisite step
2.  Shortened Maivin deployment section by removing MCAP recording and downloading and linking to these sections instead. 
3. Added Next Steps sections at the end of the deployment tutorials. 
4. Updated command templates with real session ID values to be clearer.