### PR TITLE
EDGEAI-1137: Overhaul model metadata spec for v2 two-layer outputs

### DIFF
--- a/docs/models/metadata.md
+++ b/docs/models/metadata.md
@@ -322,16 +322,16 @@ outputs:
       - num_anchors_x_features: int
       - box_coords: int
       - padding: int
-    decoder: string            # 'modelpack' or 'ultralytics' — required for outputs needing decode
+    decoder: string            # 'modelpack' | 'ultralytics' — required for outputs needing decode
     encoding: string           # 'dfl' | 'direct' | 'anchor' — required on boxes
     score_format: string       # 'per_class' | 'obj_x_class' (scores only)
-    normalized: boolean        # Box coordinates in [0,1] (true) or pixels (false)
-    stride: int                # Spatial stride (non-split spatial outputs, e.g. protos at stride 4)
+    normalized: boolean        # Coordinates in [0,1] (true) or pixels (false); boxes and detections only
+    stride: int or [int, int]  # Spatial stride; 2-element form for non-square inputs
     anchors: [[float, float]]  # Normalized anchors (ModelPack anchor-based outputs)
 
     # When the converter did NOT further split this logical output,
     # it IS the physical tensor — the following fields are present directly:
-    dtype: string              # Quantized data type
+    dtype: string              # Tensor data type (e.g. int8, uint8, float32)
     quantization:              # Quantization parameters (null for float models)
       scale: float or [float]
       zero_point: int or [int]
@@ -340,18 +340,22 @@ outputs:
 
     # When the converter split this logical output, 'outputs' contains the
     # physical children. One level of nesting only.
+    # Physical children are a quantization concept — splitting minimizes
+    # quantization error by giving each sub-tensor its own scale/zero_point.
+    # Float models do not need physical children since there is no
+    # quantization error to manage.
     outputs:
       - name: string           # Physical tensor name (as produced by the converter)
         type: string           # Semantic type (matches parent, or more specific e.g. boxes_xy)
         shape: [int]           # Physical tensor shape
         dshape: [...]          # Named dimensions for the physical shape
-        dtype: string          # Quantized data type
-        quantization:          # Per-tensor {scale, zero_point}; always required on physical outputs
+        dtype: string          # Tensor data type (e.g. int8, uint8, float32)
+        quantization:          # Per-tensor {scale, zero_point}; always present (null for float models)
           scale: float or [float]
           zero_point: int or [int]
           axis: int
           dtype: string
-        stride: int            # FPN stride for this child (per-scale splits)
+        stride: int or [int, int]  # FPN stride for this child; 2-element form for non-square inputs
         scale_index: int       # 0-based index into strides array (per-scale splits)
         activation_applied: string   # Activation fused by NPU; HAL must NOT re-apply
         activation_required: string  # Activation NOT fused; HAL must apply
@@ -476,7 +480,7 @@ The `encoding` field on a `boxes` logical output tells the HAL how to interpret 
 | Value | Channels | Description | Decode Step |
 |---|---|---|---|
 | `dfl` | `reg_max × 4` (typically 64) | Distribution Focal Loss encoding. Each coordinate is a probability distribution over `reg_max` bins. | Softmax over each `reg_max` group, then weighted sum → 4 coordinates. Common in YOLOv8, YOLO11. |
-| `direct` | 4 | Direct coordinate values — already decoded. | Dequantize only. Common in YOLO26 (reg_max=1), ARA-2 post-split, DETR. |
+| `direct` | 4 | Direct coordinate values — already decoded. | Dequantize only. Common in YOLO26 (reg_max=1), ARA-2 post-split. |
 | `anchor` | `anchors_per_cell × 4` | Anchor-based grid offsets. Each group of 4 is (tx, ty, tw, th) requiring sigmoid + anchor-scale transform. | Sigmoid + anchor transform per grid cell. Common in YOLOv5, SSD MobileNet, ModelPack. |
 
 `encoding` is required on all `boxes` outputs in v2.
@@ -532,6 +536,7 @@ Per-type semantic fields are scoped to their output type:
 
 - `encoding` → `boxes` only
 - `score_format` → `scores` only
+- `normalized` → `boxes` and `detections` only
 - `anchors` → `boxes` with `encoding: anchor` only
 - `stride` on a non-split logical output → spatial stride hint (e.g. `protos` at stride 4)
 
@@ -565,7 +570,7 @@ For each logical output in outputs[]:
 The `type` and `stride` fields on children tell the HAL which merge to perform:
 
 - **Channel sub-splits** (e.g., `boxes_xy` + `boxes_wh`): Concat along the channel dimension. Children have no `stride` field. The concatenated result matches the logical output's `shape`.
-- **Per-scale splits** (e.g., `boxes_0` + `boxes_1` + `boxes_2`): Children carry `stride` fields. Reshape each `[H, W, C]` → `[H×W, C]`, then concat along the spatial dimension (axis 0). The result shape is `[N_total, C]` where `N_total = Σ(H_i × W_i)`.
+- **Per-scale splits** (e.g., `boxes_0` + `boxes_1` + `boxes_2`): Children carry `stride` fields. Flatten each child's spatial dimensions to a single axis (`H×W`), concat along that axis, then reshape and transpose so the merged result matches the logical output's `shape` and `dshape`. The `dshape` named dimensions on both the children and the logical parent disambiguate axis ordering (e.g., NCHW vs NHWC), so no layout assumptions are hard-coded.
 
 The HAL infers the merge strategy from child fields: presence of `stride` → spatial merge; absence → channel merge.
 
@@ -1170,13 +1175,11 @@ Coverage of the two-layer output model across the detection, segmentation, and e
 | ModelPack detection | 3 | 1 per-scale | No | 3 logical `type: detection` (one per scale), no children — `encoding: anchor` |
 | ModelPack semantic seg | — | 1 | No | 1 logical `type: segmentation`, no children |
 | SSD MobileNet | 6 | 2 (box, score) | No | 2 logical (`boxes`, `scores`), 6 per-scale children each — `encoding: anchor` |
-| DETR | — | 2 (box, score) | No | 2 logical, no children — `encoding: direct` |
 | FastSAM | 3 | 3 + protos | Yes | Same as YOLOv8 segmentation |
 
 **Key observations:**
 
 - Every FPN-based architecture maps to logical outputs with per-scale children (when the converter splits) or direct outputs (when it doesn't).
-- Non-FPN models (DETR) map to direct logical outputs with no children.
 - Models with non-spatial outputs (protos) use direct logical outputs for those.
 - The only variable is whether the converter produces channel sub-splits (ARA-2 xy/wh), per-scale splits (Hailo), or no split (TFLite).
 
@@ -1610,45 +1613,6 @@ YOLOv5 is anchor-based with 3 anchors per cell. Per-scale physical channel count
     }
   ]
 }
-```
-
-### Example 8: DETR (No Split, No Children)
-
-DETR uses learned queries and global attention — no FPN, no spatial scales, no split hints. Flat outputs, no children.
-
-```yaml
-schema_version: 2
-outputs:
-  - name: queries_logits
-    type: scores
-    shape: [1, 100, 92]
-    dshape:
-      - batch: 1
-      - num_boxes: 100
-      - num_classes: 92
-    dtype: int8
-    quantization:
-      scale: 0.0078
-      zero_point: 0
-      dtype: int8
-    decoder: detr
-    score_format: per_class
-
-  - name: queries_boxes
-    type: boxes
-    shape: [1, 100, 4]
-    dshape:
-      - batch: 1
-      - num_boxes: 100
-      - box_coords: 4
-    dtype: int8
-    quantization:
-      scale: 0.0039
-      zero_point: 0
-      dtype: int8
-    decoder: detr
-    encoding: direct
-    normalized: true
 ```
 
 ### Instance Segmentation Mask Computation

--- a/docs/models/metadata.md
+++ b/docs/models/metadata.md
@@ -12,6 +12,14 @@ EdgeFirst models embed metadata that enables:
 - **Third-Party Integration**: Any training framework can produce EdgeFirst-compatible models by following this schema
 - **Converter Workflows**: Split hints and calibration artifacts enable model-agnostic conversion pipelines for quantization and target-specific compilation
 
+### Schema Version
+
+The current schema is **version 2**. The top-level `schema_version: 2` field is required on v2 metadata. Tooling uses this field to select the correct parser and to reject documents that omit fields mandated by the active version.
+
+```yaml
+schema_version: 2
+```
+
 ### Supported Formats
 
 EdgeFirst models from the [Model Zoo](index.md) (including [ModelPack](modelpack/index.md) and [Ultralytics](ultralytics/index.md)) embed metadata in format-specific locations:
@@ -115,12 +123,12 @@ def get_labels(model_path: str) -> List[str]:
     """Extract class labels from a TFLite model."""
     if not zipfile.is_zipfile(model_path):
         return []
-    
+
     with zipfile.ZipFile(model_path) as zf:
         if 'labels.txt' in zf.namelist():
             with zf.open('labels.txt') as f:
                 content = f.read().decode('utf-8').strip()
-                return [line for line in content.splitlines() 
+                return [line for line in content.splitlines()
                         if line.strip()]
     return []
 ```
@@ -137,7 +145,7 @@ from typing import Optional, List
 def get_edgefirst_metadata(model_path: str) -> Optional[dict]:
     """Extract EdgeFirst metadata from an ONNX model."""
     model = onnx.load(model_path)
-    
+
     for prop in model.metadata_props:
         if prop.key == 'edgefirst':
             return json.loads(prop.value)
@@ -146,7 +154,7 @@ def get_edgefirst_metadata(model_path: str) -> Optional[dict]:
 def get_labels(model_path: str) -> List[str]:
     """Extract class labels from an ONNX model."""
     model = onnx.load(model_path)
-    
+
     for prop in model.metadata_props:
         if prop.key == 'labels':
             return json.loads(prop.value)
@@ -155,17 +163,17 @@ def get_labels(model_path: str) -> List[str]:
 def get_quick_metadata(model_path: str) -> dict:
     """Get commonly-used fields without parsing full config."""
     model = onnx.load(model_path)
-    
+
     result = {}
-    quick_fields = ['name', 'description', 'author', 'studio_server', 
+    quick_fields = ['name', 'description', 'author', 'studio_server',
                     'session_id', 'dataset', 'dataset_id']
-    
+
     for prop in model.metadata_props:
         if prop.key in quick_fields:
             result[prop.key] = prop.value
         elif prop.key == 'labels':
             result['labels'] = json.loads(prop.value)
-    
+
     return result
 ```
 
@@ -195,11 +203,14 @@ print(f"Description: {metadata.description}")
 
 ## Metadata Schema
 
-The EdgeFirst metadata schema is organized into logical sections. All sections are optional — third-party integrations can include only the sections relevant to their use case.
+The EdgeFirst metadata schema is organized into logical sections. All sections are optional — third-party integrations can include only the sections relevant to their use case — except `schema_version`, which is required on v2 metadata.
 
 ### Complete Schema Structure
 
 ```yaml
+# Schema Version (required)
+schema_version: 2
+
 # Traceability & Identification
 host:
   studio_server: string    # Full EdgeFirst Studio hostname (e.g., test.edgefirst.studio)
@@ -234,269 +245,349 @@ model:
   detection: boolean       # Detection task enabled
   segmentation: boolean    # Segmentation task enabled
   classification: boolean  # Classification task enabled
-  split_decoder: boolean   # Whether decoder is external (see Split Decoder section)
   anchors: [[[int, int]]]  # Anchor boxes per output level
+  end2end: boolean         # True when NMS is embedded in the model graph (YOLO26 end-to-end, appended NMS)
   # ... additional model-specific parameters
 
 # Training Configuration
 trainer:
-  epochs: int              # Number of training epochs
-  batch_size: int          # Training batch size
-  weights: string          # Pretrained weights source
-  checkpoint_path: string  # Where checkpoints were saved
+  epochs: int
+  batch_size: int
+  weights: string
+  checkpoint_path: string
 
 optimizer:
-  optimizer: string        # Optimizer type (adam, adamw, sgd)
-  learning_rate: float     # Base learning rate
-  weight_decay: float      # L2 regularization strength
-  # ... additional optimizer parameters
+  optimizer: string
+  learning_rate: float
+  weight_decay: float
 
-augmentation:  # See Vision Augmentations documentation
-  random_hflip: int        # Horizontal flip probability (0-100)
-  random_mosaic: int       # Mosaic augmentation probability
-  # ... additional augmentation parameters
+augmentation:
+  random_hflip: int
+  random_mosaic: int
 
 validation:
-  iou: float               # NMS IoU threshold
-  score: float             # NMS score threshold
-  nms: string              # NMS algorithm (none, numpy, hal, tensorflow, torch)
-  normalization: string    # Input normalization (unsigned, signed)
-  preprocessing: string    # Preprocessing method (resize, letterbox)
-  skip_validation_steps: int  # Steps to skip between validations
+  iou: float
+  score: float
+  nms: string
+  normalization: string
+  preprocessing: string
+  skip_validation_steps: int
 
-export:  # See Quantization documentation for ModelPack and Ultralytics
-  export: boolean          # Whether model was quantized
-  export_input_type: string   # Input quantization type
-  export_output_type: string  # Output quantization type
-  calibration_samples: int    # Samples used for calibration
+export:
+  export: boolean
+  export_input_type: string
+  export_output_type: string
+  calibration_samples: int
 
 # Decoder Configuration (Ultralytics only)
 decoder_version: string    # YOLO architecture version: yolov5, yolov8, yolo11, yolo26
-nms: string                # NMS mode for HAL decoder: class_agnostic, class_aware
+nms: string                # HAL decoder NMS mode: class_agnostic, class_aware
 
 # Calibration Artifact (see Calibration Artifact section)
 calibration: string          # Snapshot filename: calibration-{dataset_id}-{param_hash}.safetensors
 
-# Split Hints (see Split Hints section)
+# Split Hints — INPUT metadata only, present in uncompiled ONNX/SavedModel.
+# The compiled (converted) model REPLACES split_hints with the outputs[] array.
 split_hints:
-  - type: string             # Hint type (e.g., "quantization_split")
-    target: string           # Output tensor name this hint applies to
-    input_dtype: string      # Suggested input quantization dtype
-    output_dtype: string     # Suggested output quantization dtype
-    description: string      # Human-readable purpose
-    boundaries:              # Channel boundaries within the target tensor
-      - name: string         #   Boundary region name
-        channels: [int, int] #   Channel range [start, end) (exclusive end)
+  - type: string                 # Hint type (e.g., "quantization_split")
+    target: string               # Output tensor name this hint applies to
+    input_dtype: string          # Suggested input quantization dtype
+    output_dtype: string         # Suggested output quantization dtype
+    description: string          # Human-readable purpose
+    strides: [int]               # FPN strides (optional; declares spatial structure)
+    anchors_per_cell: int        # Anchor count per cell (optional; default 1)
+    boundaries:                  # Channel boundaries within the target tensor
+      - name: string             #   Boundary region name
+        channels: [int, int]     #   Channel range [start, end) (exclusive end)
+        activation: string       #   Post-activation (sigmoid, softmax, tanh; optional)
 
 # Converter Traceability (see Converter Traceability section)
 # Converter-specific sections are added at the top level by each converter
 # Examples: "neutron": {...}, "ara2": {...}, "tflite_quantizer": {...}
 
-# Output Specification (Critical for Inference)
+# Output Specification — Two-Layer Logical/Physical Model
 outputs:
-  - name: string           # Output tensor name
-    index: int             # Tensor index
-    output_index: int      # Output order
-    shape: [int]           # Tensor shape
-    dshape:                # Named dimensions as ordered array (see dshape section)
+  - name: string               # Logical output name
+    type: string               # Semantic type: boxes, scores, objectness, mask_coefs, protos,
+                               # landmarks, classes, detections, segmentation, masks, detection
+    shape: [int]               # Reconstructed logical shape (what fallback dequant+merge produces)
+    dshape:                    # Named dimensions (see dshape section)
       - batch: int
-      - height: int                 # For spatial outputs
-      - width: int                  # For spatial outputs
-      - num_features: int           # For detection outputs
-      - num_boxes: int              # For detection outputs
-      - padding: int                # For detection outputs
-      - box_coords: int             # For detection outputs
-      - num_classes: int            # For detection outputs
-      - num_anchors_x_features: int # For detection outputs
-      - num_protos: int             # For instance segmentation
-    dtype: string          # Data type (float32, uint8, int8)
-    type: string           # Semantic type (detection, segmentation, boxes, scores, masks, protos)
-    decode: boolean        # Whether decoding is required
-    decoder: string        # Decoder type: 'modelpack' or 'ultralytics'
-    quantization:              # Quantization parameters (null if float model)
-      scale: float or [float]  #   Scale factor(s). Scalar=per-tensor, array=per-channel
-      zero_point: int or [int] #   Zero point(s). Omit for symmetric (see Quantization Parameters)
-      axis: int                #   Per-channel dimension index (required when scale is array)
-      dtype: string            #   Quantized type: int8, uint8, int16, uint16, float16
-    stride: [int, int]     # Spatial stride for this output (ModelPack)
-    anchors: [[[float, float]]]  # Normalized anchors for this output level (ModelPack only)
-    score_format: string   # Score encoding: 'per_class' or 'obj_x_class' (Ultralytics only)
-    normalized: boolean    # Box coordinates in [0,1] range (true) or pixels (false). Optional field.
+      - height: int
+      - width: int
+      - num_features: int
+      - num_boxes: int
+      - num_classes: int
+      - num_protos: int
+      - num_anchors_x_features: int
+      - box_coords: int
+      - padding: int
+    decoder: string            # 'modelpack' or 'ultralytics' — required for outputs needing decode
+    encoding: string           # 'dfl' | 'direct' | 'anchor' — required on boxes
+    score_format: string       # 'per_class' | 'obj_x_class' (scores only)
+    normalized: boolean        # Box coordinates in [0,1] (true) or pixels (false)
+    stride: int                # Spatial stride (non-split spatial outputs, e.g. protos at stride 4)
+    anchors: [[float, float]]  # Normalized anchors (ModelPack anchor-based outputs)
+
+    # When the converter did NOT further split this logical output,
+    # it IS the physical tensor — the following fields are present directly:
+    dtype: string              # Quantized data type
+    quantization:              # Quantization parameters (null for float models)
+      scale: float or [float]
+      zero_point: int or [int]
+      axis: int
+      dtype: string
+
+    # When the converter split this logical output, 'outputs' contains the
+    # physical children. One level of nesting only.
+    outputs:
+      - name: string           # Physical tensor name (as produced by the converter)
+        type: string           # Semantic type (matches parent, or more specific e.g. boxes_xy)
+        shape: [int]           # Physical tensor shape
+        dshape: [...]          # Named dimensions for the physical shape
+        dtype: string          # Quantized data type
+        quantization:          # Per-tensor {scale, zero_point}; always required on physical outputs
+          scale: float or [float]
+          zero_point: int or [int]
+          axis: int
+          dtype: string
+        stride: int            # FPN stride for this child (per-scale splits)
+        scale_index: int       # 0-based index into strides array (per-scale splits)
+        activation_applied: string   # Activation fused by NPU; HAL must NOT re-apply
+        activation_required: string  # Activation NOT fused; HAL must apply
 ```
 
 ---
 
 ## Output Specification
 
-The `outputs` section is critical for inference — it tells the runtime how to interpret model outputs.
+The `outputs` section is critical for inference — it tells the runtime how to interpret model outputs. Schema v2 introduces a **two-layer model** that separates the logical contract (what the model produces semantically) from the physical realization (what tensors the converter actually emitted).
+
+### Two-Layer Output Model
+
+Each entry in the top-level `outputs[]` array is a **logical output**. A logical output either IS a physical tensor (when the converter did not split it further) or contains an `outputs[]` array of **physical children** that realize it.
+
+**Rules:**
+
+- Logical outputs always carry a `shape` field — the reconstructed shape the HAL obtains from the fallback dequantize+merge path.
+- Each physical child self-describes with its own `name`, `shape`, `dshape`, `dtype`, and `quantization`.
+- Only **one level** of nesting is permitted (logical → physical). No deeper.
+- Semantic and decode fields (`decoder`, `encoding`, `score_format`, `normalized`) live on the logical output only — never on physical children.
+- Physical-tensor fields (`dtype`, `quantization`, `activation_applied`, `activation_required`, `scale_index`) live on the physical level. When a logical output has no children, it carries them directly because it IS the physical tensor.
+
+```yaml
+# Logical output with no split — IS the physical tensor
+- name: scores
+  type: scores
+  shape: [1, 80, 8400]
+  dshape:
+    - batch: 1
+    - num_classes: 80
+    - num_boxes: 8400
+  dtype: int8
+  quantization: {scale: 0.00392, zero_point: 0, dtype: int8}
+  decoder: ultralytics
+
+# Logical output split into per-scale physical children
+- name: boxes
+  type: boxes
+  shape: [1, 64, 8400]
+  encoding: dfl
+  decoder: ultralytics
+  normalized: true
+  outputs:
+    - name: boxes_0
+      type: boxes
+      stride: 8
+      scale_index: 0
+      shape: [1, 80, 80, 64]
+      dshape:
+        - batch: 1
+        - height: 80
+        - width: 80
+        - num_features: 64
+      dtype: uint8
+      quantization: {scale: 0.0234, zero_point: 128, dtype: uint8}
+    # ... boxes_1 (stride 16), boxes_2 (stride 32)
+```
 
 ### Output Types
 
-For Ultralytics framework models, the following output types are used:
+Logical output types used across frameworks:
 
+| Type | Description | Typical Shape (logical) |
+|---|---|---|
+| `boxes` | Bounding box coordinates | `[1, 4, num_boxes]` or `[1, reg_max×4, num_boxes]` for DFL |
+| `scores` | Per-class or class-aggregate scores | `[1, num_classes, num_boxes]` |
+| `objectness` | Objectness scores (YOLOv5-style `obj_x_class`) | `[1, anchors_per_cell, num_boxes]` |
+| `classes` | End-to-end class indices | `[1, num_boxes, 1]` |
+| `mask_coefs` | Mask coefficients for instance segmentation | `[1, num_protos, num_boxes]` |
+| `protos` | Instance segmentation prototypes | `[1, num_protos, H, W]` |
+| `landmarks` | Facial / keypoint landmarks | `[1, num_landmarks, num_boxes]` |
+| `detections` | Fully decoded post-NMS detections (end-to-end) | `[1, max_det, 6]` (x1,y1,x2,y2,conf,class) |
+| `segmentation` | Semantic segmentation output (ModelPack) | `[1, H, W, num_classes]` |
+| `masks` | Semantic segmentation masks (ModelPack) | `[1, H, W]` |
+| `detection` | ModelPack anchor-grid raw output requiring anchor decode | `[1, H, W, anchors×features]` |
 
-| Type                  | Description                                  | Typical Shape                    |
-| --------------------- | -------------------------------------------- | -------------------------------- |
-| `detection`         | Raw detection output (needs to be split)     | `[1, num_features, num_boxes]` |
-| `boxes`             | Split bounding boxes                         | `[1, 4, num_boxes]`            |
-| `scores`            | Split class scores                           | `[1, num_classes, num_boxes]`  |
-| `classes`           | Class label indices (end-to-end split models) | `[1, num_boxes, 1]`           |
-| `mask_coefficients` | Split coefficients for instance segmentation | `[1, num_protos, num_boxes]`   |
-| `protos`            | Instance segmentation prototypes             | `[1, H, W, num_protos]` (NHWC) |
+Physical-child subtypes (appear only inside `outputs[]` children):
 
-**`score_format` field** (Ultralytics only):
-
-| Value | Description | Architecture |
-|-------|-------------|--------------|
-| `per_class` | Each anchor outputs `[nc]` class probabilities directly | YOLOv8, YOLO11, YOLO26 |
-| `obj_x_class` | Each anchor outputs `[1 + nc]` where final score = objectness × class confidence | YOLOv5 |
-
-When `score_format` is absent, the validator falls back to a shape-based heuristic on the feature dimension: `nc+5` features per anchor (4 box coordinates + 1 objectness + `nc` class probabilities) implies `obj_x_class` (e.g., `[1, 85, 8400]` for 80 classes).
-
-!!! note "HAL Score Format"
-    HAL determines score format from `decoder_version` rather than `score_format`. `yolov5` applies objectness × class; all other versions use per-class scores directly.
-
-For ModelPack framework models the following output types are used:
-
-| Type             | Description                           | Typical Shape                             |
-| ---------------- | ------------------------------------- | ----------------------------------------- |
-| `detection`    | Raw detection output (needs decoding) | `[1, H, W, num_anchors_x_features]` |
-| `boxes`        | Bounding boxes                        | `[1, num_boxes, 1, 4]`                  |
-| `scores`       | Class scores                          | `[1, num_boxes, num_classes]`           |
-| `segmentation` | Semantic segmentation output          | `[1, H, W, num_classes]`               |
-| `masks`        | Semantic segmentation masks           | `[1, H, W]`                             |
-
-### Segmentation Types
-
-EdgeFirst supports two distinct segmentation approaches:
-
-#### Semantic Segmentation (ModelPack)
-
-Per-pixel classification **without object instances**. Each pixel is assigned a class label, but individual objects are not distinguished.
-
-**Use cases:**
-
-- Drivable surface detection
-- Lane segmentation
-- Sky/ground separation
-- Terrain classification
-
-**Output structure:**
-
-```yaml
-outputs:
-  - name: "segmentation_output"
-    type: segmentation
-    shape: [1, 480, 640, 5]    # [batch, H, W, num_classes]
-    dshape:
-      - batch: 1
-      - height: 480
-      - width: 640
-      - num_classes: 5
-    decoder: modelpack
-```
-
-#### Instance Segmentation (Ultralytics)
-
-Per-pixel classification **with object instances**. Each detected object gets its own mask, enabling fine-grained object boundaries beyond bounding boxes.
-
-**Use cases:**
-
-- Individual person segmentation
-- Vehicle instance masks
-- Product segmentation
-- Fine-grained object detection
-
-**Output structure:**
-
-```yaml
-# Detection output with mask coefficients
-outputs:
-  - name: "detection_output"
-    type: detection
-    shape: [1, 116, 8400]      # [batch, 4+nc+32, num_boxes] - includes 32 mask coefficients
-    dshape:
-      - batch: 1
-      - num_features: 116        # 4 box coords + 80 classes + 32 mask coefficients
-      - num_boxes: 8400
-    decoder: ultralytics
-
-  # Prototype masks for instance computation
-  - name: "protos_output"
-    type: protos
-    shape: [1, 32, 160, 160]   # [batch, num_protos, H, W] NCHW
-    dshape:
-      - batch: 1
-      - num_protos: 32
-      - height: 160
-      - width: 160
-    decoder: ultralytics
-```
-
-**Final mask computation:**
-
-```python
-# For each detected object with mask_coefficients [32]:
-instance_mask = sigmoid(mask_coefficients @ protos)  # [32] @ [32, H, W] → [H, W]
-# Crop to bounding box region for final instance mask
-```
+| Subtype | When Used | Description |
+|---|---|---|
+| `boxes_xy` | ARA-2 channel sub-split | xy coordinates split for independent INT16 quantization |
+| `boxes_wh` | ARA-2 channel sub-split | wh coordinates split for independent INT16 quantization |
+| *(same as parent)* | Per-scale split | Each FPN scale produces one child with the parent's type |
 
 ### The `dshape` Field
 
-The `dshape` field provides **named dimensions** for easier interpretation of tensor shapes. This is especially useful when shapes vary between data layouts (NCHW vs NHWC).
+The `dshape` field provides **named dimensions** for each axis, making tensor shapes self-describing. Consumers resolve axes like `height` or `num_classes` by name rather than by position, which matters because ONNX uses NCHW and TFLite uses NHWC — the same dimension lives at a different index depending on format. `dshape` applies to both logical and physical outputs; each level describes its own shape.
 
 ```yaml
+# Logical-level dshape
 outputs:
-  - name: "output_0"
+  - name: output0
     shape: [1, 84, 8400]       # Raw shape
     dshape:                    # Named dimensions as ordered array
       - batch: 1
-      - num_features: 84         # 4 box coords + 80 classes
+      - num_features: 84       # 4 box coords + 80 classes
       - num_boxes: 8400
 ```
 
 **Standard dimension names:**
 
-| Name                       | Description                                                                                       |
-| -------------------------- | ------------------------------------------------------------------------------------------------- |
-| `batch`                  | Batch size (typically 1 for inference)                                                            |
-| `height`                 | Spatial height                                                                                    |
-| `width`                  | Spatial width                                                                                     |
-| `num_classes`            | Number of classification classes                                                                  |
-| `num_features`           | Feature dimension (box coords + classes + mask coefficients)                                      |
-| `num_boxes`              | Number of detection boxes/anchors                                                                 |
-| `num_protos`             | Number of prototype masks (instance segmentation)                                                 |
-| `num_anchors_x_features` | Combined anchor and feature dimension for ModelPack grid outputs (anchors × features per anchor)  |
-| `padding`                | Padding/alignment dimension used to satisfy expected tensor shapes. Must always be 1              |
-| `box_coords`             | The coordinates of the boxes. Must be 4                                                           |
+| Name | Description |
+|---|---|
+| `batch` | Batch size (typically 1 for inference) |
+| `height` | Spatial height |
+| `width` | Spatial width |
+| `num_classes` | Number of classification classes |
+| `num_features` | Feature dimension (box coords + classes + mask coefficients) |
+| `num_boxes` | Number of detection boxes/anchors |
+| `num_protos` | Number of prototype masks (instance segmentation) |
+| `num_anchors_x_features` | Combined anchor × features-per-anchor dimension (ModelPack grid outputs) |
+| `padding` | Padding/alignment dimension used to satisfy expected tensor shapes. Must always be 1 |
+| `box_coords` | The coordinates of the boxes. Must be 4 |
+
+`dshape` entries are ordered objects — the position of each key matches the axis position in `shape`. Ordering is authoritative for consumers mapping shapes to names.
+
+### Box Encoding
+
+The `encoding` field on a `boxes` logical output tells the HAL how to interpret the raw channel data after dequantization.
+
+| Value | Channels | Description | Decode Step |
+|---|---|---|---|
+| `dfl` | `reg_max × 4` (typically 64) | Distribution Focal Loss encoding. Each coordinate is a probability distribution over `reg_max` bins. | Softmax over each `reg_max` group, then weighted sum → 4 coordinates. Common in YOLOv8, YOLO11. |
+| `direct` | 4 | Direct coordinate values — already decoded. | Dequantize only. Common in YOLO26 (reg_max=1), ARA-2 post-split, DETR. |
+| `anchor` | `anchors_per_cell × 4` | Anchor-based grid offsets. Each group of 4 is (tx, ty, tw, th) requiring sigmoid + anchor-scale transform. | Sigmoid + anchor transform per grid cell. Common in YOLOv5, SSD MobileNet, ModelPack. |
+
+`encoding` is required on all `boxes` outputs in v2.
+
+### Score Format
+
+The `score_format` field on a `scores` logical output disambiguates YOLOv5's `obj_x_class` encoding from the default per-class encoding used by YOLOv8/v11/v26:
+
+| Value | Description | Architecture |
+|---|---|---|
+| `per_class` | Each anchor outputs `[nc]` class probabilities directly | YOLOv8, YOLO11, YOLO26, default |
+| `obj_x_class` | Each anchor outputs `[nc]` class probabilities; a separate `objectness` logical output provides `[1]` per anchor. Final detection confidence = `objectness × class_score` per anchor | YOLOv5 |
+
+When `score_format` is `obj_x_class`, the model produces a separate `objectness` logical output as a sibling of `scores` at the logical level.
 
 ### Decoding Information
 
-For outputs with `decode: true`, the metadata provides all information needed to decode:
+The presence of a `decoder` field on a logical output signals that post-processing is required. Outputs consumed directly (e.g., `protos`) may omit `decoder`.
 
 ```yaml
-outputs:
-  - name: "detection_output_0"
-    type: detection
-    decode: true
-    decoder: modelpack
-    shape: [1, 40, 40, 54]      # Grid output
-    dshape:
-      - batch: 1
-      - height: 40
-      - width: 40
-      - num_anchors_x_features: 54
-    anchors:                    # Normalized anchor boxes
-      - [0.054, 0.065]
-      - [0.089, 0.139]
-      - [0.195, 0.196]
-    quantization:               # For dequantization
-      scale: 0.176
-      zero_point: 198
-      dtype: uint8
+- name: boxes
+  type: boxes
+  shape: [1, 64, 8400]
+  encoding: dfl
+  decoder: ultralytics      # Post-processing required
+  normalized: true
+  outputs: [...]            # Physical per-scale children
+
+- name: protos
+  type: protos
+  shape: [1, 32, 160, 160]
+  stride: 4
+  dtype: int8
+  quantization: {scale: 0.0156, zero_point: 0, dtype: int8}
+  # No 'decoder' field — consumed directly
 ```
 
-### Quantization Parameters
+### Logical vs Physical Field Placement
+
+Semantic and decode fields live on the **logical output** and apply to all children. Physical children carry only tensor-level fields.
+
+**Root-level only:** `decoder_version`, `nms` (HAL NMS mode). These describe model-wide behaviour and never appear inside an `outputs[]` entry.
+
+**Logical output only:** `decoder`, `encoding`, `score_format`, `normalized`, `anchors`
+
+**Physical output only:** `quantization` (always required), `dtype`, `scale_index`, `activation_applied`, `activation_required`
+
+**Both levels:** `name`, `type`, `shape`, `dshape`, `stride`
+
+When a logical output has no children, it also carries `dtype` and `quantization` directly — it IS the physical tensor.
+
+Per-type semantic fields are scoped to their output type:
+
+- `encoding` → `boxes` only
+- `score_format` → `scores` only
+- `anchors` → `boxes` with `encoding: anchor` only
+- `stride` on a non-split logical output → spatial stride hint (e.g. `protos` at stride 4)
+
+---
+
+## HAL Decoder Algorithm
+
+The HAL uses the two-layer `outputs[]` structure to decode any converter's decomposition.
+
+```
+For each logical output in outputs[]:
+  if output has "outputs" children:
+    # Converter split this logical output
+    if HAL has optimized decoder for this (type, children types) combination:
+      # Direct path: use quantized children directly
+      decode_optimized(children)
+    else:
+      # Fallback: dequantize each child, reassemble into logical shape
+      for child in children:
+        dequantize(child) -> float32
+      merge children -> logical tensor (concat along appropriate axis)
+      decode_standard(logical_tensor)
+  else:
+    # No split — tensor IS the logical output
+    dequantize(output) -> float32
+    decode_standard(output)
+```
+
+### Merge Strategy
+
+The `type` and `stride` fields on children tell the HAL which merge to perform:
+
+- **Channel sub-splits** (e.g., `boxes_xy` + `boxes_wh`): Concat along the channel dimension. Children have no `stride` field. The concatenated result matches the logical output's `shape`.
+- **Per-scale splits** (e.g., `boxes_0` + `boxes_1` + `boxes_2`): Children carry `stride` fields. Reshape each `[H, W, C]` → `[H×W, C]`, then concat along the spatial dimension (axis 0). The result shape is `[N_total, C]` where `N_total = Σ(H_i × W_i)`.
+
+The HAL infers the merge strategy from child fields: presence of `stride` → spatial merge; absence → channel merge.
+
+### Direct Path Examples
+
+| Target | Logical Type | Children Types | Direct Decoder |
+|---|---|---|---|
+| ARA-2 | `boxes` | `boxes_xy`, `boxes_wh` | `box_assembly` — INT16 dequant + dist2bbox in one pass |
+| Hailo | `scores` | `scores` ×3 (per-scale) | Per-scale sigmoid already applied, just spatial concat |
+
+### Fallback Path
+
+The fallback always works for any decomposition:
+
+1. Dequantize each child to float32 using its `quantization` parameters.
+2. Merge using the inferred strategy.
+3. The result is a float32 tensor matching the logical output's `shape`.
+4. Pass to the standard decoder pipeline.
+
+---
+
+## Quantization Parameters
 
 Quantized models store integer values instead of floats. Each output tensor includes parameters to convert back to floating-point using the dequantization formula:
 
@@ -513,10 +604,10 @@ EdgeFirst supports two quantization granularities and two quantization modes:
 
 For detailed specifications, see the [ONNX QuantizeLinear operator](https://onnx.ai/onnx/operators/onnx__QuantizeLinear.html) and [LiteRT 8-bit quantization specification](https://ai.google.dev/edge/litert/conversion/tensorflow/quantization/quantization_spec).
 
-#### Quantization Object Schema
+### Quantization Object Schema
 
 | Field | Type | Required | Description |
-|-------|------|----------|-------------|
+|---|---|---|---|
 | `scale` | float or \[float\] | Yes | Scale factor(s). Scalar = per-tensor, array = per-channel |
 | `zero_point` | int or \[int\] | No | Zero point offset(s). Omit for symmetric quantization (implies 0) |
 | `axis` | int | When per-channel | Tensor dimension index that the scale/zero_point arrays correspond to |
@@ -530,7 +621,7 @@ For detailed specifications, see the [ONNX QuantizeLinear operator](https://onnx
 - When `zero_point` is present: asymmetric (affine) quantization
 - `quantization: null` means the tensor is not quantized (float model)
 
-#### Examples
+### Examples
 
 ```yaml
 # Per-tensor symmetric
@@ -561,7 +652,7 @@ quantization:
 quantization: null
 ```
 
-#### Dequantization Code
+### Dequantization Code
 
 ```python
 import numpy as np
@@ -581,14 +672,33 @@ def dequantize(raw_output: np.ndarray, quantization: dict) -> np.ndarray:
     return (raw_output.astype(np.float32) - zero_point) * scale
 ```
 
-#### Framework Conventions
+### Framework Conventions
 
 | Framework | Per-Tensor | Per-Channel | Symmetric | Axis Field |
-|-----------|-----------|-------------|-----------|------------|
+|---|---|---|---|---|
 | ONNX | Scalar scale | 1-D scale + `axis` | Implicit (zero_point=0) | `axis` (default 1) |
 | TFLite/LiteRT | Scalar (1-element array) | 1-D scale + `quantized_dimension` | Implicit (zero_point=0 for weights) | `quantized_dimension` |
 | TensorRT | Scalar scale | Per-channel scale | Always symmetric | Output channel axis |
 | PyTorch | Scalar scale | 1-D scale + `axis` | Explicit `qscheme` enum | `axis` parameter |
+
+### Target-Specific Term Mapping
+
+Some NPU toolchains use different terminology internally. Converters translate at the boundary — the compiled `edgefirst.json` always uses the standard terms above.
+
+**Kinara ARA-2** (ioparams.json, qmode 9 — asymmetric):
+
+| Kinara term | edgefirst.json term | Notes |
+|---|---|---|
+| `outputScale` / `outputQn` | `scale` | Identical value for qmode 9. For symmetric qmodes (0–3), Kinara's `qn` is 1/scale — but the ARA-2 converter always uses qmode 9 |
+| `offset` | `zero_point` | Identical value |
+| `bpp` + `isSigned` | `dtype` | `bpp=1, signed` → `int8`, `bpp=2, unsigned` → `uint16`, etc. |
+
+**Hailo** (HEF quantization info):
+
+| Hailo term | edgefirst.json term |
+|---|---|
+| `qp_scale` | `scale` |
+| `qp_zp` | `zero_point` |
 
 ---
 
@@ -606,7 +716,7 @@ Deep learning frameworks use different memory layouts for tensor data. The metad
 - **TFLite** (TensorFlow): Uses channels-last (NHWC) which is optimized for CPU and mobile inference
 - **ONNX** (PyTorch-derived): Uses channels-first (NCHW) which is optimized for GPU and NPU inference
 
-The metadata's `outputs` section reports shapes in the model's native format. When integrating with inference runtimes, ensure your input preprocessing matches the expected layout.
+The metadata's `outputs` section reports shapes in the model's native format. When integrating with inference runtimes, ensure your input preprocessing matches the expected layout. The `dshape` field lets consumers look up dimensions by name rather than relying on positional assumptions that differ between layouts.
 
 ### Metadata Fields
 
@@ -619,7 +729,7 @@ input:
   # - NCHW: [batch, channels, height, width] e.g., [1, 3, 640, 640]
 
 outputs:
-  - name: "output_0"
+  - name: output_0
     shape: [1, 640, 640, 3]   # TFLite: NHWC
     # shape: [1, 3, 640, 640] # ONNX: NCHW
 ```
@@ -676,7 +786,7 @@ For quantized models (INT8), the quantization parameters handle the scaling inte
 The `cameraadaptor` field specifies the expected input format for the model. See [Camera Adaptor](cameraadaptor.md) for details on how this enables models to consume native camera formats without runtime conversion.
 
 | Value | Description | Channel Order |
-|-------|-------------|---------------|
+|---|---|---|
 | `rgb` | Standard RGB | Red, Green, Blue |
 | `bgr` | OpenCV default | Blue, Green, Red |
 | `rgba` | RGB with alpha | Red, Green, Blue, Alpha |
@@ -690,10 +800,18 @@ The `cameraadaptor` field specifies the expected input format for the model. See
 
 The `validation` section records the recommended settings based on how the model was trained. These parameters are **informational preferences** — they document the model author's intended configuration for validation and inference.
 
+!!! note "Two distinct `nms` fields"
+    This document uses `nms` at two levels with different semantics:
+
+    - **`validation.nms`** (this section) — selects the NMS *implementation* (`hal`, `numpy`, `tensorflow`, `torch`) or `none` for models with embedded NMS.
+    - **root-level `nms`** (see [HAL NMS Field](#hal-nms-field)) — selects HAL decoder *behaviour* (`class_agnostic` vs `class_aware`).
+
+    The two fields are independent and can coexist. Keep the distinction in mind when reading the rest of this section.
+
 ### Parameter Semantics
 
 | Parameter | Description | Default | Override at Runtime? |
-|-----------|-------------|---------|---------------------|
+|---|---|---|---|
 | `iou` | NMS IoU threshold | `0.7` | Yes |
 | `score` | NMS confidence score threshold | `0.001` | Yes |
 | `nms` | NMS algorithm | *(not set)* | See below |
@@ -712,7 +830,7 @@ Both produce post-NMS output in `[x1, y1, x2, y2, conf, class, ...]` format. Det
 ### Allowed `nms` Values
 
 | Value | Description |
-|-------|-------------|
+|---|---|
 | `none` | No external NMS. For models with embedded NMS — either architectural end-to-end (YOLO26) or engine-embedded (ONNX/TRT/TFLite with NMS ops appended). Supports both detection and segmentation |
 | `numpy` | NumPy-based NMS implementation (default fallback) |
 | `hal` | EdgeFirst HAL decoder NMS |
@@ -723,15 +841,12 @@ When `--override` is set, the validator reads `validation.nms` from the model me
 
 ### Box Coordinate Format (`normalized`)
 
-The `normalized` field on detection and boxes outputs specifies the coordinate format:
+The `normalized` field on `boxes` and `detections` outputs specifies the coordinate format:
 
 | Value | Description | Coordinate Range |
-|-------|-------------|------------------|
+|---|---|---|
 | `true` | Normalized coordinates relative to model input dimensions | `[0.0, 1.0]` |
 | `false` | Pixel coordinates relative to model input (letterboxed frame) | `[0, width]` / `[0, height]` |
-| *(absent)* | Must be inferred from output values | Check if any coordinate > 1.0 |
-
-**When `normalized` is absent**, the coordinate format must be inferred by examining the output values. If any bounding box coordinate exceeds `1.0`, the coordinates are in pixels; otherwise, assume normalized.
 
 **Normalized coordinates are preferred** because they:
 
@@ -748,82 +863,35 @@ The `normalized` field on detection and boxes outputs specifies the coordinate f
     Coordinates are always relative to the **letterboxed model input**, not the original image aspect ratio. The caller must apply the inverse letterbox transform to map boxes back to original image coordinates regardless of whether `normalized` is `true` or `false`.
 
 ```yaml
-# Example: End-to-end model with pixel coordinates
+# End-to-end model with pixel coordinates
 outputs:
-  - name: "output0"
-    type: detection
-    shape: [1, 100, 6]    # [batch, max_det, x1+y1+x2+y2+conf+class]
-    normalized: false      # Pixel coordinates
+  - name: output0
+    type: detections
+    shape: [1, 100, 6]       # [batch, max_det, x1+y1+x2+y2+conf+class]
+    dshape:
+      - batch: 1
+      - num_boxes: 100
+      - num_features: 6
+    normalized: false         # Pixel coordinates
     decoder: ultralytics
 ```
 
 ---
 
-## Post-Processing & Split Decoder
+## Post-Processing & Two-Layer Outputs
 
-### What is Split Decoder?
+The two-layer `outputs[]` structure (introduced in [Output Specification](#output-specification)) is descriptive: converters declare the logical contract and — when they split the tensor further — describe the physical decomposition they produced. This section covers the post-processing decoder contract that consumers honour at inference time. For the layout of logical outputs per architecture, see [Architecture Survey](#architecture-survey).
 
-The `split_decoder` field indicates the model's outputs have been modified from the standard architecture to improve INT8 quantization performance. The details are framework-specific:
+### Decoding Flow
 
-- **ModelPack**: Raw grid features instead of decoded boxes (dequantize before anchor decode)
-- **Ultralytics**: Detection tensor split into separate tensors for per-tensor quantization — `boxes` and `scores` for detection (2 outputs), or `boxes`, `scores`, `mask_coefficients`, and `protos` for segmentation (4 outputs). Box coordinates are normalized to [0,1]
+When a logical output has a `decoder` field set, the inference pipeline must:
 
-```yaml
-model:
-  split_decoder: true    # Outputs modified for quantization (see framework docs)
-  split_decoder: false   # Standard output format
-```
-
-See framework documentation for implementation details.
-
-### Why Split Decoder Exists
-
-Quantization introduces precision loss. Split decoder addresses this differently per framework:
-
-**[ModelPack](modelpack/index.md)**: For small objects or high-resolution inputs, applying anchor calculations in INT8 would compound rounding errors. By deferring decoding until after dequantization, we preserve box accuracy.
-
-**[Ultralytics](ultralytics/index.md)**: The monolithic detection tensor contains boxes, scores, and mask coefficients with very different value ranges. Splitting them into separate tensors allows per-tensor quantization scales, preserving accuracy for each component independently. Box coordinates are normalized to [0,1] for both detection and segmentation, which reduces the dynamic range and further improves INT8 quantization accuracy. See [Ultralytics Quantization](ultralytics/quantize.md) for details and accuracy benchmarks.
-
-### Decoding Process
-
-When `split_decoder: true`, the inference pipeline must:
-
-1. **Run model inference** → Get quantized outputs
-2. **Dequantize outputs** → Convert INT8 to float32 using per-output scale/zero_point
-3. **Apply decoding** → Framework-specific: anchor decode (ModelPack) or box format conversion (Ultralytics)
-4. **Run NMS** → Filter overlapping detections
-
-```python
-# Example decoding flow for split_decoder models
-for output_spec in metadata['outputs']:
-    if output_spec.get('decode', False):
-        # Dequantize first
-        quant = output_spec['quantization']
-        scale = np.float32(quant['scale'])
-        zp = quant.get('zero_point', 0)
-        raw_float = (raw_int8.astype(np.float32) - zp) * scale
-        # For per-channel quantization, use the dequantize() function above
-
-        # Then decode (framework-specific)
-        if output_spec['decoder'] == 'modelpack':
-            boxes = decode_yolo_grid(raw_float, output_spec['anchors'], output_spec['stride'])
-        elif output_spec['decoder'] == 'ultralytics':
-            # boxes, scores, mask_coefficients are separate outputs
-            pass  # Use output type to determine handling
-```
-
-### Output Types with Split Decoder
-
-| Framework | `split_decoder` | Task | Output Types |
-|-----------|-----------------|------|--------------|
-| ModelPack | `true` | Detection | `detection` (raw grid, needs anchor decode) |
-| ModelPack | `false` | Detection | `boxes`, `scores` (decoded) |
-| Ultralytics | `true` | Detection | `boxes`, `scores` |
-| Ultralytics | `true` | Segmentation | `boxes`, `scores`, `mask_coefficients`, `protos` |
-| Ultralytics | `false` | Detection | `detection` (monolithic) |
-| Ultralytics | `false` | Segmentation | `detection`, `protos` (monolithic) |
-| Ultralytics (end-to-end) | n/a | Detection | `boxes`, `scores`, `classes` |
-| Ultralytics (end-to-end) | n/a | Segmentation | `boxes`, `scores`, `classes`, `mask_coefficients`, `protos` |
+1. **Run model inference** → Get quantized physical tensors
+2. **Identify the logical output** → Each entry in `outputs[]`, with or without children
+3. **Dequantize physical tensors** → Using each child's `quantization` (or the logical's own if no children)
+4. **Reassemble into the logical tensor** → If the logical output has physical children, merge them per the rules in [HAL Decoder Algorithm — Merge Strategy](#merge-strategy) (channel concat for sub-splits, spatial concat for per-scale splits). If there are no children, the logical output IS the tensor.
+5. **Apply decoder** → Framework-specific: anchor decode (`modelpack`), DFL/direct decode (`ultralytics`)
+6. **Run NMS** → Unless the model has embedded NMS (`validation.nms: none`)
 
 ### Decoder Field
 
@@ -831,15 +899,13 @@ The `decoder` field specifies which decoding algorithm to use:
 
 ```yaml
 outputs:
-  - name: "detection_output_0"
-    type: detection
-    decode: true
-    decoder: modelpack    # Use ModelPack YOLO-style grid decoding
+  - name: boxes
+    type: boxes
+    encoding: dfl
+    decoder: ultralytics
 ```
 
-#### Supported Decoders
-
-##### `modelpack` — Anchor-Based YOLO Decoder
+#### `modelpack` — Anchor-Based YOLO Decoder
 
 Used by [ModelPack](modelpack/index.md) models. Traditional YOLO-style grid decoding with pre-defined anchor boxes.
 
@@ -857,35 +923,35 @@ wh = (sigmoid(wh) * 2) ** 2 * anchors * stride * 0.5
 xyxy = concat([xy - wh, xy + wh]) / input_dims  # normalized xyxy
 ```
 
-**Required metadata fields:**
+**Required metadata fields** (on the logical `detection` output):
 
 ```yaml
 outputs:
-  - decoder: modelpack
-    anchors:              # Required - normalized anchor boxes
+  - type: detection
+    decoder: modelpack
+    encoding: anchor
+    anchors:              # Required — normalized anchor boxes for this scale
       - [0.054, 0.065]
       - [0.089, 0.139]
-    stride: [16, 16]      # Required - spatial stride
+    stride: [16, 16]      # Required — spatial stride
 ```
 
-!!! warning "Deprecated: `decoder: yolov8`"
-    The decoder value `yolov8` is deprecated. Use `ultralytics` instead. Existing models with `decoder: yolov8` will continue to work — the validator automatically normalizes `yolov8` to `ultralytics` with a deprecation warning.
-
-##### `ultralytics` — Anchor-Free DFL Decoder
+#### `ultralytics` — Anchor-Free DFL Decoder
 
 Used by [Ultralytics](ultralytics/index.md) models (YOLOv5, YOLOv8, YOLO11, YOLO26). Modern anchor-free detection using Distribution Focal Loss (DFL).
 
 **Characteristics:**
 
 - **Anchor-free**: Uses anchor points (grid centers) instead of pre-defined boxes
-- **DFL regression**: Converts 16-bin distribution to box coordinates
-- **Unified architecture**: Same decoder for YOLOv5, YOLOv8, YOLO11, and YOLO26
+- **DFL regression**: Converts 16-bin distribution to box coordinates (`encoding: dfl`)
+- **Direct coordinates**: YOLO26 uses reg_max=1 for direct 4-channel output (`encoding: direct`)
+- **Unified architecture**: Same decoder for YOLOv5, YOLOv8, YOLO11, YOLO26 — differences are captured by `encoding`, `score_format`, and `decoder_version`
 
 **Decoding formula:**
 
 ```python
-# DFL converts 16-bin distribution to coordinate value
-box = dfl(raw_box)  # [batch, 64, anchors] → [batch, 4, anchors]
+# DFL converts 16-bin distribution to coordinate value (encoding: dfl only)
+box = dfl(raw_box)  # [batch, 64, anchors] -> [batch, 4, anchors]
 
 # dist2bbox converts LTRB distances to boxes
 x1y1 = anchor_points - lt
@@ -893,22 +959,12 @@ x2y2 = anchor_points + rb
 # Returns xywh in pixel coordinates (ONNX float) or [0,1] normalized (TFLite INT8)
 ```
 
-**Metadata structure:**
-
-```yaml
-outputs:
-  - decoder: ultralytics
-    anchors: null         # Not used - anchor-free
-    # Strides are implicit: [8, 16, 32] for P3/P4/P5 outputs
-```
-
-**Version differences:**
-All Ultralytics versions use the same anchor-free `Detect` class. Differences are in backbone architecture:
+**Version differences** — all Ultralytics versions use the same anchor-free `Detect` class. Differences are in backbone architecture:
 
 | Version | Backbone Blocks | Classification Head |
-|---------|-----------------|---------------------|
-| YOLOv5  | C3              | Conv→Conv→Conv2d    |
-| YOLOv8  | C2f             | Conv→Conv→Conv2d    |
+|---|---|---|
+| YOLOv5  | C3              | Conv→Conv→Conv2d        |
+| YOLOv8  | C2f             | Conv→Conv→Conv2d        |
 | YOLO11  | C3k2, C2PSA     | DWConv→Conv (efficient) |
 | YOLO26  | C3k2, A2C2f     | DWConv→Conv (efficient) |
 
@@ -925,7 +981,7 @@ decoder_version: yolov8    # Traditional model requiring external NMS
 **Supported values:**
 
 | Value | Architecture | NMS Handling |
-|-------|--------------|--------------|
+|---|---|---|
 | `yolov5` | YOLOv5 | External NMS required |
 | `yolov8` | YOLOv8 | External NMS required |
 | `yolo11` | YOLO11 | External NMS required |
@@ -934,21 +990,21 @@ decoder_version: yolov8    # Traditional model requiring external NMS
 !!! note "Naming Convention"
     The naming follows Ultralytics conventions: `yolov5` and `yolov8` include the 'v' prefix, while `yolo11` and `yolo26` do not (Ultralytics dropped the 'v' starting with YOLO11).
 
-**When `decoder_version` is `yolo26`:**
+**When `decoder_version` is `yolo26` and `model.end2end: true`:**
 
 - The model uses one-to-one matching heads with NMS embedded in the architecture
-- Output format is `[x1, y1, x2, y2, conf, class, ...]` (post-NMS)
+- Output format is `type: detections` with shape `[1, max_det, 6]` = `[x1, y1, x2, y2, conf, class]`
 - The HAL decoder uses end-to-end model types regardless of the `nms` field
 - No external NMS is applied
 
 **When `decoder_version` is absent or any other value:**
 
 - Traditional YOLO architecture requiring external NMS
-- The `nms` field controls which NMS algorithm the HAL decoder uses
+- The root-level `nms` field controls which NMS algorithm the HAL decoder uses
 
 ### HAL NMS Field
 
-The `nms` field at the config root level controls the HAL decoder's NMS behavior:
+The root-level `nms` field controls the HAL decoder's NMS behavior:
 
 ```yaml
 nms: class_agnostic    # Suppress overlapping boxes regardless of class (default)
@@ -957,46 +1013,860 @@ nms: class_aware       # Only suppress boxes with the same class label
 ```
 
 | Value | Behavior |
-|-------|----------|
+|---|---|
 | `class_agnostic` | Suppress overlapping boxes regardless of class label (default) |
 | `class_aware` | Only suppress boxes that share the same class AND overlap |
 
-!!! warning "Different from `validation.nms`"
-    The root-level `nms` field controls **HAL decoder behavior** (class-agnostic vs class-aware). The `validation.nms` field in the validation section specifies the **NMS implementation** to use during validation (hal, numpy, tensorflow, etc.) or `none` for models with embedded NMS.
+!!! warning "Two distinct `nms` fields"
+    This document uses `nms` at two levels with different semantics:
 
-**Example configuration for YOLO26 end-to-end model:**
+    - **Root-level `nms`** (this field) — HAL decoder *behaviour*: `class_agnostic` vs `class_aware`.
+    - **`validation.nms`** (see [Validation Parameters](#validation-parameters)) — NMS *implementation*: `hal`, `numpy`, `tensorflow`, `torch`, or `none`.
 
-```yaml
-decoder_version: yolo26
-outputs:
-  - decoder: ultralytics
-    type: detection
-    shape: [1, 100, 6]
-    normalized: false
-    dshape:
-      - batch: 1
-      - num_boxes: 100
-      - num_features: 6
-validation:
-  nms: none    # Model has embedded NMS
+    The two fields are independent and can coexist.
+
+---
+
+## Split Hints
+
+Split hints encode model-specific knowledge about where natural quantization boundaries exist within output tensors. The training framework identifies these boundaries based on its knowledge of the model architecture; the converter decides whether to apply them and how far to decompose beyond them.
+
+### Lifecycle
+
+Split hints are **input metadata only**. They live in the uncompiled (ONNX / SavedModel) `edgefirst.json` and are consumed by the converter. The compiled (converted) model **replaces** `split_hints` with the compiled `outputs[]` array — the two-layer logical/physical structure is the authoritative description of the compiled model.
+
+```
+┌──────────────────────┐     ┌──────────────────────┐     ┌──────────────────┐
+│  Training Framework  │     │      Converter        │     │       HAL        │
+│                      │     │                       │     │                  │
+│  Embeds split_hints  │────▶│  Reads split_hints    │────▶│  Reads compiled  │
+│  in ONNX metadata    │     │  Splits (at minimum   │     │  outputs[]       │
+│                      │     │  on logical bounds,   │     │                  │
+│  Logical boundaries  │     │  optionally further)  │     │  Direct path or  │
+│  only.               │     │                       │     │  fallback path   │
+│                      │     │  Replaces split_hints │     │                  │
+│                      │     │  with outputs[] using │     │                  │
+│                      │     │  two-layer structure  │     │                  │
+└──────────────────────┘     └──────────────────────┘     └──────────────────┘
 ```
 
-**Example configuration for traditional YOLOv8 model:**
+1. **ONNX / SavedModel** — Training framework embeds `split_hints` in `edgefirst.json` metadata. These describe logical boundaries only; there is no `outputs[]` decomposition yet.
+2. **Converter** — Reads `split_hints`, performs the split (at minimum on logical bounds, optionally further). The compiled `edgefirst.json` replaces `split_hints` with the actual `outputs[]` array.
+3. **HAL** — Reads the compiled `outputs[]` array. Each logical output either has direct tensor data (no children) or has `outputs[]` children that are the real physical tensors.
+
+### Purpose
+
+When a single output tensor contains channels with different value distributions (e.g., [0,1]-bounded box coordinates alongside unbounded linear projections), a shared quantization scale degrades accuracy. Split hints tell converters where these natural boundaries exist so they can apply independent quantization scales to each region.
+
+### Schema
 
 ```yaml
+split_hints:
+  - type: quantization_split
+    target: output0
+    input_dtype: uint8
+    output_dtype: int8
+    description: "YOLOv8 detection head: boxes + scores + mask coefficients"
+    strides: [8, 16, 32]
+    anchors_per_cell: 1
+    boundaries:
+      - name: boxes
+        channels: [0, 4]
+      - name: scores
+        channels: [4, 84]
+        activation: sigmoid
+      - name: mask_coefs
+        channels: [84, 116]
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `type` | string | Yes | Hint type identifier. Converters ignore types they do not understand |
+| `target` | string | Yes | Name of the output tensor this hint applies to |
+| `input_dtype` | string | No | Suggested input quantization dtype (e.g., `uint8`) |
+| `output_dtype` | string | No | Suggested output quantization dtype (e.g., `int8`) |
+| `description` | string | No | Human-readable description of the split |
+| `strides` | int[] | No | FPN stride values (ascending). Declares spatial structure for converters that can perform per-scale decomposition |
+| `anchors_per_cell` | int | No | For anchor-based models (default: 1). Per-scale channel count = `anchors_per_cell × boundary_channels` |
+| `boundaries` | object[] | Yes | Ordered list of channel regions within the target tensor |
+
+### Boundary Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Free-form semantic label (e.g., `boxes`, `scores`, `mask_coefs`, `landmarks`, `objectness`, `confidence`) |
+| `channels` | [int, int] | Yes | Channel range `[start, end)` in the logical output. Always post-decode, post-DFL logical channels (e.g., 4 for decoded box coords, not 64 for DFL-encoded) |
+| `activation` | string | No | Post-activation to apply (`sigmoid`, `softmax`, `tanh`). Converters that can fuse it into the NPU do so; others note it for the HAL |
+
+Boundary names are free-form semantic labels — not a fixed enum. Common ones: `boxes`, `scores`, `objectness`, `mask_coefs`, `landmarks`, `confidence`.
+
+### Behavior Rules
+
+- `split_hints` is an array — multiple hints can coexist (e.g., one per output tensor).
+- Each hint has a `type` field — converters **must ignore** types they do not understand (forward compatibility).
+- Converter UI presents all known split types from this schema as options.
+- If the user enables a split type and matching hints exist in the model, the converter applies them.
+- If the user enables a split type and no matching hints exist, the converter warns (not an error) and proceeds without splitting.
+- Hints include suggested quantization defaults (`input_dtype`, `output_dtype`) that converters use as UI defaults; the user can override them.
+- Boundary `channels` ranges must be non-overlapping and cover the full channel dimension of the target tensor when taken together.
+- End-to-end models (`model.end2end: true`) are **incompatible with split_hints** — there is nothing to split because the output is already the final result.
+
+### Hint Types
+
+#### `quantization_split`
+
+Channel boundaries within an output tensor that have different value distributions and benefit from independent quantization scales. The converter applies graph surgery to split the tensor at the specified boundaries, then quantizes each resulting tensor independently.
+
+**Example: Ultralytics segmentation model**
+
+The monolithic detection output `[1, 116, 8400]` contains 84 detection channels ([0,1]-bounded boxes + scores) and 32 mask coefficient channels (unbounded linear projection). Splitting at channel 84 allows independent quantization scales:
+
+```yaml
+split_hints:
+  - type: quantization_split
+    target: output0
+    input_dtype: uint8
+    output_dtype: int8
+    description: "Separate mask coefficients from detection channels for independent quantization"
+    strides: [8, 16, 32]
+    boundaries:
+      - name: boxes
+        channels: [0, 4]
+      - name: scores
+        channels: [4, 84]
+        activation: sigmoid
+      - name: mask_coefs
+        channels: [84, 116]
+```
+
+### Per-Task Split Recommendations
+
+Based on quantization experiments:
+
+| Task | Hints | Rationale |
+|---|---|---|
+| **Detection** | One `quantization_split` on output0 with `boxes` + `scores` boundaries | Per-component scales improve INT8 precision; boxes and scores have different distributions |
+| **Segmentation** | One `quantization_split` on output0 with `boxes` + `scores` + `mask_coefs` boundaries | Mask coefficients (unbounded) especially benefit from their own scale |
+| **End-to-end (YOLO26 `end2end: true`)** | None | Output is already post-NMS; nothing to split |
+| **Single-output (BEV)** | None | Single output with uniform value distribution |
+
+---
+
+## Architecture Survey
+
+Coverage of the two-layer output model across the detection, segmentation, and end-to-end architectures currently supported by the EdgeFirst ecosystem. The list grows as new architectures are onboarded — the two-layer model is general and accommodates additional families (SCRFD, EfficientDet, YOLACT, DETR variants, etc.) without schema changes.
+
+| Architecture | Scales | Heads | Monolithic in ONNX? | Two-Layer Mapping |
+|---|---|---|---|---|
+| YOLOv8 / YOLO11 detection | 3 | 2 (box, score) | Yes | 2 logical (`boxes`, `scores`), optional per-scale or xy/wh children |
+| YOLOv8 / YOLO11 segmentation | 3 | 3 + protos | Yes | 3 logical w/ children + 1 direct (`protos`) |
+| YOLO26 detection | 3 | 2 (box, score) | Yes | 2 logical, optional children — `encoding: direct` |
+| YOLO26 segmentation | 3 | 3 + protos | Yes | 3 logical w/ children + 1 direct — `encoding: direct` |
+| YOLO26 end-to-end | — | 1 | — | 1 logical `detections`, no children |
+| YOLOv5 detection | 3 | combined (obj×cls) | No | 3 logical (`boxes`, `objectness`, `scores`), per-scale children — `score_format: obj_x_class` |
+| YOLOv5 segmentation | 3 | combined + protos | No | 4 logical w/ children + 1 direct (`protos`) |
+| ModelPack detection | 3 | 1 per-scale | No | 3 logical `type: detection` (one per scale), no children — `encoding: anchor` |
+| ModelPack semantic seg | — | 1 | No | 1 logical `type: segmentation`, no children |
+| SSD MobileNet | 6 | 2 (box, score) | No | 2 logical (`boxes`, `scores`), 6 per-scale children each — `encoding: anchor` |
+| DETR | — | 2 (box, score) | No | 2 logical, no children — `encoding: direct` |
+| FastSAM | 3 | 3 + protos | Yes | Same as YOLOv8 segmentation |
+
+**Key observations:**
+
+- Every FPN-based architecture maps to logical outputs with per-scale children (when the converter splits) or direct outputs (when it doesn't).
+- Non-FPN models (DETR) map to direct logical outputs with no children.
+- Models with non-spatial outputs (protos) use direct logical outputs for those.
+- The only variable is whether the converter produces channel sub-splits (ARA-2 xy/wh), per-scale splits (Hailo), or no split (TFLite).
+
+---
+
+## Full Examples
+
+### Example 1: ModelPack Semantic Segmentation
+
+Direct logical output, no children — the output tensor IS the physical tensor.
+
+```yaml
+schema_version: 2
+outputs:
+  - name: segmentation_output
+    type: segmentation
+    shape: [1, 480, 640, 5]
+    dshape:
+      - batch: 1
+      - height: 480
+      - width: 640
+      - num_classes: 5
+    dtype: uint8
+    quantization:
+      scale: 0.00392
+      zero_point: 0
+      dtype: uint8
+    decoder: modelpack
+```
+
+### Example 2: ModelPack Detection (Anchor Grid, Per-Scale Flat)
+
+Each FPN scale is a direct logical output with `encoding: anchor`. No children — ModelPack grid outputs carry all streams (boxes + objectness + scores) in the channel dimension and are decoded by the `modelpack` decoder using `anchors` + `stride`.
+
+```yaml
+schema_version: 2
+outputs:
+  - name: output_0
+    type: detection
+    shape: [1, 40, 40, 54]    # 3 anchors × (4 box + 1 obj + 13 classes)
+    dshape:
+      - batch: 1
+      - height: 40
+      - width: 40
+      - num_anchors_x_features: 54
+    dtype: uint8
+    quantization:
+      scale: 0.176
+      zero_point: 198
+      dtype: uint8
+    decoder: modelpack
+    encoding: anchor
+    stride: [16, 16]
+    anchors:
+      - [0.054, 0.065]
+      - [0.089, 0.139]
+      - [0.195, 0.196]
+
+  - name: output_1
+    type: detection
+    shape: [1, 20, 20, 54]
+    dshape:
+      - batch: 1
+      - height: 20
+      - width: 20
+      - num_anchors_x_features: 54
+    dtype: uint8
+    quantization:
+      scale: 0.172
+      zero_point: 201
+      dtype: uint8
+    decoder: modelpack
+    encoding: anchor
+    stride: [32, 32]
+    anchors:
+      - [0.125, 0.126]
+      - [0.208, 0.260]
+      - [0.529, 0.491]
+```
+
+### Example 3: Ultralytics YOLOv8 Detection — TFLite (Flat, No Children)
+
+The TFLite quantizer splits boxes from scores (per `split_hints`) but does not decompose further — the DFL distribution is preserved in the compiled graph and decoded by the HAL. Each logical output IS the physical tensor.
+
+```yaml
+schema_version: 2
 decoder_version: yolov8
 nms: class_agnostic
 outputs:
-  - decoder: ultralytics
-    type: detection
-    shape: [1, 84, 8400]
+  - name: boxes
+    type: boxes
+    shape: [1, 64, 8400]         # DFL: 4 coords × reg_max=16
     dshape:
       - batch: 1
-      - num_features: 84
+      - num_features: 64
       - num_boxes: 8400
-validation:
-  nms: hal    # Use HAL decoder NMS
+    dtype: int8
+    quantization:
+      scale: 0.00392
+      zero_point: 0
+      dtype: int8
+    decoder: ultralytics
+    encoding: dfl                # HAL applies softmax + weighted-sum to recover 4 coords
+    normalized: true
+
+  - name: scores
+    type: scores
+    shape: [1, 80, 8400]
+    dshape:
+      - batch: 1
+      - num_classes: 80
+      - num_boxes: 8400
+    dtype: int8
+    quantization:
+      scale: 0.00392
+      zero_point: 0
+      dtype: int8
+    decoder: ultralytics
+    score_format: per_class
 ```
+
+### Example 4: Ultralytics YOLOv8 Detection — ARA-2 (xy/wh Channel Split)
+
+ARA-2 splits `boxes` into `boxes_xy` and `boxes_wh` for independent INT16 quantization.
+
+```json
+{
+  "schema_version": 2,
+  "decoder_version": "yolov8",
+  "nms": "class_agnostic",
+  "outputs": [
+    {
+      "name": "boxes",
+      "type": "boxes",
+      "shape": [1, 4, 8400, 1],
+      "dshape": [
+        {"batch": 1},
+        {"box_coords": 4},
+        {"num_boxes": 8400},
+        {"padding": 1}
+      ],
+      "encoding": "direct",
+      "decoder": "ultralytics",
+      "normalized": true,
+      "outputs": [
+        {
+          "name": "_model_22_Div_1_output_0",
+          "type": "boxes_xy",
+          "shape": [1, 2, 8400, 1],
+          "dshape": [
+            {"batch": 1},
+            {"box_coords": 2},
+            {"num_boxes": 8400},
+            {"padding": 1}
+          ],
+          "dtype": "int16",
+          "quantization": {"scale": 3.129e-05, "zero_point": 0, "dtype": "int16"}
+        },
+        {
+          "name": "_model_22_Sub_1_output_0",
+          "type": "boxes_wh",
+          "shape": [1, 2, 8400, 1],
+          "dshape": [
+            {"batch": 1},
+            {"box_coords": 2},
+            {"num_boxes": 8400},
+            {"padding": 1}
+          ],
+          "dtype": "int16",
+          "quantization": {"scale": 3.149e-05, "zero_point": 0, "dtype": "int16"}
+        }
+      ]
+    },
+    {
+      "name": "scores",
+      "type": "scores",
+      "shape": [1, 80, 8400, 1],
+      "dshape": [
+        {"batch": 1},
+        {"num_classes": 80},
+        {"num_boxes": 8400},
+        {"padding": 1}
+      ],
+      "dtype": "int8",
+      "quantization": {"scale": 0.00392, "zero_point": 0, "dtype": "int8"},
+      "decoder": "ultralytics",
+      "score_format": "per_class"
+    }
+  ]
+}
+```
+
+### Example 5: Ultralytics YOLOv8 Segmentation — Hailo (Per-Scale, 10 Physical Outputs)
+
+Hailo splits at per-scale Conv nodes, producing one physical tensor per FPN scale for each logical output. `protos` is not split.
+
+```json
+{
+  "schema_version": 2,
+  "decoder_version": "yolov8",
+  "nms": "class_agnostic",
+  "outputs": [
+    {
+      "name": "boxes",
+      "type": "boxes",
+      "shape": [1, 64, 8400],
+      "dshape": [{"batch": 1}, {"num_features": 64}, {"num_boxes": 8400}],
+      "encoding": "dfl",
+      "decoder": "ultralytics",
+      "normalized": true,
+      "outputs": [
+        {
+          "name": "boxes_0", "type": "boxes", "stride": 8, "scale_index": 0,
+          "shape": [1, 80, 80, 64],
+          "dshape": [{"batch": 1}, {"height": 80}, {"width": 80}, {"num_features": 64}],
+          "dtype": "uint8", "quantization": {"scale": 0.0234, "zero_point": 128, "dtype": "uint8"}
+        },
+        {
+          "name": "boxes_1", "type": "boxes", "stride": 16, "scale_index": 1,
+          "shape": [1, 40, 40, 64],
+          "dshape": [{"batch": 1}, {"height": 40}, {"width": 40}, {"num_features": 64}],
+          "dtype": "uint8", "quantization": {"scale": 0.0198, "zero_point": 130, "dtype": "uint8"}
+        },
+        {
+          "name": "boxes_2", "type": "boxes", "stride": 32, "scale_index": 2,
+          "shape": [1, 20, 20, 64],
+          "dshape": [{"batch": 1}, {"height": 20}, {"width": 20}, {"num_features": 64}],
+          "dtype": "uint8", "quantization": {"scale": 0.0312, "zero_point": 125, "dtype": "uint8"}
+        }
+      ]
+    },
+    {
+      "name": "scores",
+      "type": "scores",
+      "shape": [1, 80, 8400],
+      "dshape": [{"batch": 1}, {"num_classes": 80}, {"num_boxes": 8400}],
+      "decoder": "ultralytics",
+      "score_format": "per_class",
+      "outputs": [
+        {
+          "name": "scores_0", "type": "scores", "stride": 8, "scale_index": 0,
+          "shape": [1, 80, 80, 80],
+          "dshape": [{"batch": 1}, {"height": 80}, {"width": 80}, {"num_classes": 80}],
+          "dtype": "uint8", "quantization": {"scale": 0.00392, "zero_point": 0, "dtype": "uint8"},
+          "activation_applied": "sigmoid"
+        },
+        {
+          "name": "scores_1", "type": "scores", "stride": 16, "scale_index": 1,
+          "shape": [1, 40, 40, 80],
+          "dshape": [{"batch": 1}, {"height": 40}, {"width": 40}, {"num_classes": 80}],
+          "dtype": "uint8", "quantization": {"scale": 0.00389, "zero_point": 0, "dtype": "uint8"},
+          "activation_applied": "sigmoid"
+        },
+        {
+          "name": "scores_2", "type": "scores", "stride": 32, "scale_index": 2,
+          "shape": [1, 20, 20, 80],
+          "dshape": [{"batch": 1}, {"height": 20}, {"width": 20}, {"num_classes": 80}],
+          "dtype": "uint8", "quantization": {"scale": 0.00401, "zero_point": 0, "dtype": "uint8"},
+          "activation_applied": "sigmoid"
+        }
+      ]
+    },
+    {
+      "name": "mask_coefs",
+      "type": "mask_coefs",
+      "shape": [1, 32, 8400],
+      "dshape": [{"batch": 1}, {"num_protos": 32}, {"num_boxes": 8400}],
+      "decoder": "ultralytics",
+      "outputs": [
+        {
+          "name": "mask_coefs_0", "type": "mask_coefs", "stride": 8, "scale_index": 0,
+          "shape": [1, 80, 80, 32],
+          "dshape": [{"batch": 1}, {"height": 80}, {"width": 80}, {"num_protos": 32}],
+          "dtype": "uint8", "quantization": {"scale": 0.0156, "zero_point": 64, "dtype": "uint8"}
+        },
+        {
+          "name": "mask_coefs_1", "type": "mask_coefs", "stride": 16, "scale_index": 1,
+          "shape": [1, 40, 40, 32],
+          "dshape": [{"batch": 1}, {"height": 40}, {"width": 40}, {"num_protos": 32}],
+          "dtype": "uint8", "quantization": {"scale": 0.0148, "zero_point": 66, "dtype": "uint8"}
+        },
+        {
+          "name": "mask_coefs_2", "type": "mask_coefs", "stride": 32, "scale_index": 2,
+          "shape": [1, 20, 20, 32],
+          "dshape": [{"batch": 1}, {"height": 20}, {"width": 20}, {"num_protos": 32}],
+          "dtype": "uint8", "quantization": {"scale": 0.0171, "zero_point": 60, "dtype": "uint8"}
+        }
+      ]
+    },
+    {
+      "name": "protos",
+      "type": "protos",
+      "shape": [1, 32, 160, 160],
+      "dshape": [{"batch": 1}, {"num_protos": 32}, {"height": 160}, {"width": 160}],
+      "dtype": "uint8",
+      "quantization": {"scale": 0.0203, "zero_point": 45, "dtype": "uint8"},
+      "stride": 4
+    }
+  ]
+}
+```
+
+### Example 6: YOLO26 End-to-End (Embedded NMS)
+
+The model graph contains NMS; output is fully decoded. Single flat logical output with `type: detections`, no children. The root-level `nms` field is intentionally omitted — there is no external HAL NMS step to configure when NMS is embedded in the graph.
+
+```yaml
+schema_version: 2
+decoder_version: yolo26
+# Root-level 'nms' omitted: embedded NMS means no HAL NMS to configure.
+model:
+  end2end: true
+outputs:
+  - name: output0
+    type: detections
+    shape: [1, 100, 6]
+    dshape:
+      - batch: 1
+      - num_boxes: 100
+      - num_features: 6      # x1, y1, x2, y2, conf, class
+    dtype: int8
+    quantization:
+      scale: 0.0078
+      zero_point: 0
+      dtype: int8
+    normalized: false
+    decoder: ultralytics
+validation:
+  nms: none                  # Tells validators not to invoke external NMS
+```
+
+### Example 7: YOLOv5 Detection (Anchor-Based, Per-Scale Children, `obj_x_class`)
+
+YOLOv5 is anchor-based with 3 anchors per cell. Per-scale physical channel counts are multiplied by `anchors_per_cell`: boxes = 3×4 = 12, objectness = 3×1 = 3, scores = 3×80 = 240.
+
+```json
+{
+  "schema_version": 2,
+  "decoder_version": "yolov5",
+  "nms": "class_agnostic",
+  "outputs": [
+    {
+      "name": "boxes",
+      "type": "boxes",
+      "shape": [1, 12, 8400],
+      "dshape": [{"batch": 1}, {"num_features": 12}, {"num_boxes": 8400}],
+      "encoding": "anchor",
+      "decoder": "ultralytics",
+      "normalized": false,
+      "outputs": [
+        {
+          "name": "boxes_0", "type": "boxes", "stride": 8, "scale_index": 0,
+          "shape": [1, 80, 80, 12],
+          "dshape": [{"batch": 1}, {"height": 80}, {"width": 80}, {"num_features": 12}],
+          "dtype": "uint8", "quantization": {"scale": 0.032, "zero_point": 128, "dtype": "uint8"}
+        },
+        {
+          "name": "boxes_1", "type": "boxes", "stride": 16, "scale_index": 1,
+          "shape": [1, 40, 40, 12],
+          "dshape": [{"batch": 1}, {"height": 40}, {"width": 40}, {"num_features": 12}],
+          "dtype": "uint8", "quantization": {"scale": 0.029, "zero_point": 130, "dtype": "uint8"}
+        },
+        {
+          "name": "boxes_2", "type": "boxes", "stride": 32, "scale_index": 2,
+          "shape": [1, 20, 20, 12],
+          "dshape": [{"batch": 1}, {"height": 20}, {"width": 20}, {"num_features": 12}],
+          "dtype": "uint8", "quantization": {"scale": 0.035, "zero_point": 126, "dtype": "uint8"}
+        }
+      ]
+    },
+    {
+      "name": "objectness",
+      "type": "objectness",
+      "shape": [1, 3, 8400],
+      "dshape": [{"batch": 1}, {"num_features": 3}, {"num_boxes": 8400}],
+      "decoder": "ultralytics",
+      "outputs": [
+        {
+          "name": "objectness_0", "type": "objectness", "stride": 8, "scale_index": 0,
+          "shape": [1, 80, 80, 3],
+          "dshape": [{"batch": 1}, {"height": 80}, {"width": 80}, {"num_features": 3}],
+          "dtype": "uint8", "quantization": {"scale": 0.0039, "zero_point": 0, "dtype": "uint8"},
+          "activation_applied": "sigmoid"
+        },
+        {
+          "name": "objectness_1", "type": "objectness", "stride": 16, "scale_index": 1,
+          "shape": [1, 40, 40, 3],
+          "dshape": [{"batch": 1}, {"height": 40}, {"width": 40}, {"num_features": 3}],
+          "dtype": "uint8", "quantization": {"scale": 0.0041, "zero_point": 0, "dtype": "uint8"},
+          "activation_applied": "sigmoid"
+        },
+        {
+          "name": "objectness_2", "type": "objectness", "stride": 32, "scale_index": 2,
+          "shape": [1, 20, 20, 3],
+          "dshape": [{"batch": 1}, {"height": 20}, {"width": 20}, {"num_features": 3}],
+          "dtype": "uint8", "quantization": {"scale": 0.0038, "zero_point": 0, "dtype": "uint8"},
+          "activation_applied": "sigmoid"
+        }
+      ]
+    },
+    {
+      "name": "scores",
+      "type": "scores",
+      "shape": [1, 240, 8400],
+      "dshape": [{"batch": 1}, {"num_features": 240}, {"num_boxes": 8400}],
+      "decoder": "ultralytics",
+      "score_format": "obj_x_class",
+      "outputs": [
+        {
+          "name": "scores_0", "type": "scores", "stride": 8, "scale_index": 0,
+          "shape": [1, 80, 80, 240],
+          "dshape": [{"batch": 1}, {"height": 80}, {"width": 80}, {"num_features": 240}],
+          "dtype": "uint8", "quantization": {"scale": 0.0039, "zero_point": 0, "dtype": "uint8"},
+          "activation_applied": "sigmoid"
+        },
+        {
+          "name": "scores_1", "type": "scores", "stride": 16, "scale_index": 1,
+          "shape": [1, 40, 40, 240],
+          "dshape": [{"batch": 1}, {"height": 40}, {"width": 40}, {"num_features": 240}],
+          "dtype": "uint8", "quantization": {"scale": 0.0040, "zero_point": 0, "dtype": "uint8"},
+          "activation_applied": "sigmoid"
+        },
+        {
+          "name": "scores_2", "type": "scores", "stride": 32, "scale_index": 2,
+          "shape": [1, 20, 20, 240],
+          "dshape": [{"batch": 1}, {"height": 20}, {"width": 20}, {"num_features": 240}],
+          "dtype": "uint8", "quantization": {"scale": 0.0041, "zero_point": 0, "dtype": "uint8"},
+          "activation_applied": "sigmoid"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Example 8: DETR (No Split, No Children)
+
+DETR uses learned queries and global attention — no FPN, no spatial scales, no split hints. Flat outputs, no children.
+
+```yaml
+schema_version: 2
+outputs:
+  - name: queries_logits
+    type: scores
+    shape: [1, 100, 92]
+    dshape:
+      - batch: 1
+      - num_boxes: 100
+      - num_classes: 92
+    dtype: int8
+    quantization:
+      scale: 0.0078
+      zero_point: 0
+      dtype: int8
+    decoder: detr
+    score_format: per_class
+
+  - name: queries_boxes
+    type: boxes
+    shape: [1, 100, 4]
+    dshape:
+      - batch: 1
+      - num_boxes: 100
+      - box_coords: 4
+    dtype: int8
+    quantization:
+      scale: 0.0039
+      zero_point: 0
+      dtype: int8
+    decoder: detr
+    encoding: direct
+    normalized: true
+```
+
+### Instance Segmentation Mask Computation
+
+For instance segmentation outputs (Ultralytics), the final per-object mask is computed from mask coefficients and prototypes:
+
+```python
+# For each detected object with mask_coefs [32]:
+instance_mask = sigmoid(mask_coefs @ protos)  # [32] @ [32, H, W] -> [H, W]
+# Crop to bounding box region for final instance mask
+```
+
+---
+
+## Calibration Artifact
+
+Training frameworks produce a calibration artifact containing preprocessed, ready-to-consume calibration data. This artifact enables model-agnostic converters to perform quantization without knowing the model's preprocessing pipeline, input normalization, or data augmentation.
+
+### Rationale
+
+The training stage always generates calibration data because:
+
+- The model knows its own preprocessing (normalization, resizing, color space, [CameraAdaptor](cameraadaptor.md))
+- Multi-input models (e.g., camera + radar fusion) require model-specific preprocessing per input
+- Smart sample selection (percentile bounds, coverage optimization) runs once at training time
+- Converters become truly model-agnostic — they receive ready-to-consume tensors
+
+### Format
+
+Calibration data is stored in [safetensors](https://huggingface.co/docs/safetensors/) format with named tensors corresponding to model input names.
+
+### Naming Convention
+
+Calibration filenames encode the dataset and generation parameters for deterministic caching:
+
+```
+calibration-{dataset_id}-{param_hash}.safetensors
+```
+
+**Example:** `calibration-ds-2bcc-a1b2c3d4.safetensors`
+
+- `{dataset_id}` — Studio dataset label (e.g., `ds-2bcc`)
+- `{param_hash}` — Deterministic hash of the calibration generation parameters
+
+### Parameter Hash
+
+The parameter hash is computed from the inputs that determine calibration content. The hash is over the **parameters**, not the **content** — two trainers using the same parameters will produce the same hash even if they select different samples.
+
+Parameters included in the hash:
+
+| Parameter | Example | Why |
+|---|---|---|
+| Dataset ID | `ds-2bcc` | Which dataset |
+| Annotation set ID | `as-1a3f` | Which annotation version |
+| Validation group | `val` | Which split |
+| Image size | `640x640` | Resize target |
+| Preprocessing | `normalize_uint8`, `letterbox` | How pixels are transformed |
+| CameraAdaptor | `rgb`, `yuyv`, `grey` | Color space / channel config |
+| Calibration coverage | `10` | Percentage of validation set |
+| Selection algorithm | `greedy_coverage_v1` | Algorithm version (invalidates cache on algorithm changes) |
+
+The hash function and parameter serialization order are defined by each training framework but must be deterministic and consistent across runs.
+
+### Storage: Studio Snapshots
+
+Calibration artifacts are stored as **Studio snapshots**, not session artifacts. The filename is the cache key.
+
+**Trainer workflow:**
+
+1. Compute the parameter hash from calibration generation parameters
+2. Build the filename: `calibration-{dataset_id}-{param_hash}.safetensors`
+3. Look up the snapshot by filename via Studio API
+4. If the snapshot exists → download and use it (skip generation)
+5. If not → generate the calibration set, publish it as a snapshot with this filename
+
+This means a calibration set is generated **once** for a given set of parameters. Subsequent training runs with the same dataset, preprocessing, and coverage reuse the cached snapshot automatically.
+
+### Tensor Naming
+
+Tensor names in the safetensors file **must match the model's input tensor names**. Converters load all tensors by name and feed them to the calibration generator.
+
+#### Single-Input Model
+
+For models with a single image input (e.g., Ultralytics detection or segmentation):
+
+```
+calibration-ds-2bcc-a1b2c3d4.safetensors:
+  images: float32 [500, 3, 640, 640]    # [num_samples, channels, height, width]
+```
+
+- Tensor name `images` matches the model's input tensor name
+- Samples are preprocessed identically to training/inference (normalized to [0.0, 1.0], resized, CameraAdaptor applied)
+- Typical sample count: ~500 images (10% of validation set or 500, whichever is smaller)
+
+#### Multi-Input Model
+
+For models with multiple inputs (e.g., camera + radar fusion):
+
+```
+calibration-ds-2bcc-a1b2c3d4.safetensors:
+  camera: float32 [500, 3, 360, 640]    # [num_samples, channels, height, width]
+  radar:  float32 [500, 200, 128, 8]    # [num_samples, range_bins, doppler_bins, features]
+```
+
+- Each tensor name (`camera`, `radar`) matches the corresponding model input name
+- Each input is preprocessed according to its own pipeline (image normalization for camera, range-doppler processing for radar)
+- All inputs have the same number of samples (first dimension)
+
+### Converter Usage
+
+Converters consume the calibration artifact as follows:
+
+1. Read `edgefirst.json` from the training session to get the calibration filename
+2. Download the calibration snapshot by filename via Studio API
+3. Load all tensors using any safetensors-compatible library
+4. Match tensor names to model input names
+5. Iterate over samples (first dimension) to feed the calibration generator
+
+```python
+from safetensors import safe_open
+
+with safe_open(calibration_path, framework="numpy") as f:
+    tensor_names = f.keys()
+    num_samples = f.get_tensor(next(iter(tensor_names))).shape[0]
+
+    for i in range(num_samples):
+        feed_dict = {name: f.get_tensor(name)[i:i+1] for name in tensor_names}
+        yield feed_dict  # Feed to TFLiteConverter representative_dataset or equivalent
+```
+
+---
+
+## Converter Traceability
+
+When a converter processes a model, it augments the existing `edgefirst.json` with a converter-specific section at the top level. This provides full traceability of all conversion steps applied to the model.
+
+### Rules
+
+- Converters **augment** — they never replace or remove existing fields in `edgefirst.json` except for `split_hints`, which is replaced by the compiled `outputs[]` array per the split-hints lifecycle.
+- Each converter adds a top-level key named after itself (e.g., `"tflite_quantizer"`, `"neutron"`, `"ara2"`, `"hailo"`).
+- The converter section records conversion parameters, version, and any decisions made during conversion.
+- Multiple converter sections can coexist when a model passes through a pipeline chain (e.g., TFLite Quantizer followed by Neutron Converter).
+
+### Converter Section Schema
+
+Each converter section is a free-form object, but should include at minimum:
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | string | Converter app version |
+| `timestamp` | string | ISO 8601 conversion timestamp |
+| `task` | string | Studio batch task ID for this conversion step (e.g., `bt-3a1f`) |
+| `splits_applied` | string[] | List of `split_hints[].type` values that were consumed |
+
+Additional fields are converter-specific and documented by each converter app.
+
+### Example: Single Converter
+
+After TFLite quantization of an Ultralytics detection model:
+
+```json
+{
+  "schema_version": 2,
+  "host": { "studio_server": "test.edgefirst.studio", "...": "..." },
+  "model": { "...": "..." },
+  "outputs": [ "..." ],
+
+  "tflite_quantizer": {
+    "version": "1.0.0",
+    "timestamp": "2026-03-20T15:30:00Z",
+    "task": "bt-3a1f",
+    "input_dtype": "uint8",
+    "output_dtype": "int8",
+    "calibration": "calibration-ds-2bcc-a1b2c3d4.safetensors",
+    "calibration_samples": 500,
+    "splits_applied": ["quantization_split"],
+    "quantizer": "mlir"
+  }
+}
+```
+
+### Example: Pipeline Chain
+
+After TFLite quantization followed by Neutron conversion for i.MX95 deployment:
+
+```json
+{
+  "schema_version": 2,
+  "host": { "...": "..." },
+  "model": { "...": "..." },
+  "outputs": [ "..." ],
+
+  "tflite_quantizer": {
+    "version": "1.0.0",
+    "timestamp": "2026-03-20T15:30:00Z",
+    "task": "bt-3a1f",
+    "input_dtype": "uint8",
+    "output_dtype": "int8",
+    "calibration": "calibration-ds-2bcc-a1b2c3d4.safetensors",
+    "calibration_samples": 500,
+    "splits_applied": [],
+    "quantizer": "mlir"
+  },
+
+  "neutron": {
+    "version": "2.1.0",
+    "timestamp": "2026-03-20T15:45:00Z",
+    "task": "bt-3a20",
+    "target": "imx95",
+    "neutron_version": "1.2.0",
+    "delegate": "neutron"
+  }
+}
+```
+
+### Ordering
+
+When a model passes through multiple converters, the chronological order is determined by the `timestamp` field in each converter section. The `task` field links each conversion step back to its Studio batch task (e.g., `bt-3a1f`) for full audit trail.
 
 ---
 
@@ -1005,7 +1875,7 @@ validation:
 ONNX models exported from [ModelPack](modelpack/index.md) or [Ultralytics](ultralytics/index.md) include additional official metadata fields:
 
 | Field | ModelPack Value | Ultralytics Value | Purpose |
-|-------|-----------------|-------------------|---------|
+|---|---|---|---|
 | `producer_name` | "EdgeFirst ModelPack" | "EdgeFirst Ultralytics" | Identifies producing framework |
 | `producer_version` | Package version | Package version | Version tracking |
 | `graph.name` | Model name | Model name | Graph identification |
@@ -1014,7 +1884,7 @@ ONNX models exported from [ModelPack](modelpack/index.md) or [Ultralytics](ultra
 Custom metadata properties (all string values):
 
 | Key | Content | Purpose |
-|-----|---------|---------|
+|---|---|---|
 | `edgefirst` | Full config as JSON | Complete configuration |
 | `name` | Model name | Quick access (no JSON parsing) |
 | `description` | Model description | Quick access |
@@ -1037,21 +1907,41 @@ Any training framework can produce EdgeFirst-compatible models by embedding the 
 For basic [EdgeFirst Perception](../perception/index.md) stack compatibility:
 
 ```yaml
+schema_version: 2
+
 input:
-  shape: [1, 640, 640, 3]  # Input tensor shape (NHWC or NCHW)
+  shape: [1, 640, 640, 3]
   cameraadaptor: rgb
 
 model:
   detection: true
   segmentation: false
-  split_decoder: true  # or false if decoder is built-in
 
 outputs:
-  - name: "output_0"
-    shape: [1, 8400, 84]
+  - name: boxes
+    type: boxes
+    shape: [1, 4, 8400]
+    dshape:
+      - batch: 1
+      - box_coords: 4
+      - num_boxes: 8400
     dtype: float32
-    type: boxes  # or detection if needs decoding
-    decode: false
+    quantization: null
+    encoding: direct
+    decoder: ultralytics
+    normalized: true
+
+  - name: scores
+    type: scores
+    shape: [1, 80, 8400]
+    dshape:
+      - batch: 1
+      - num_classes: 80
+      - num_boxes: 8400
+    dtype: float32
+    quantization: null
+    decoder: ultralytics
+    score_format: per_class
 
 dataset:
   classes:
@@ -1064,6 +1954,8 @@ dataset:
 For production MLOps integration with [EdgeFirst Studio](../studio/index.md):
 
 ```yaml
+schema_version: 2
+
 host:
   studio_server: test.edgefirst.studio
   project_id: "1123"
@@ -1097,7 +1989,7 @@ import os
 
 def add_edgefirst_metadata(tflite_path: str, config: dict, labels: List[str]):
     """Add EdgeFirst metadata to a TFLite model."""
-    
+
     # Write config and labels to temp files in a cross-platform way
     with tempfile.TemporaryDirectory() as tmpdir:
         config_path = os.path.join(tmpdir, 'edgefirst.yaml')
@@ -1141,18 +2033,18 @@ from typing import List
 
 def add_edgefirst_metadata(onnx_path: str, config: dict, labels: List[str]):
     """Add EdgeFirst metadata to an ONNX model."""
-    
+
     model = onnx.load(onnx_path)
-    
+
     # Set official ONNX fields
     model.producer_name = 'My Training Framework'
     model.producer_version = '1.0.0'
-    
+
     if config.get('name'):
         model.graph.name = config['name']
     if config.get('description'):
         model.doc_string = config['description']
-    
+
     # Add custom metadata
     metadata = {
         'edgefirst': json.dumps(config),
@@ -1166,13 +2058,13 @@ def add_edgefirst_metadata(onnx_path: str, config: dict, labels: List[str]):
         'dataset': config.get('dataset', {}).get('name', ''),
         'dataset_id': str(config.get('dataset', {}).get('id', '')),
     }
-    
+
     for key, value in metadata.items():
         if value:
             prop = model.metadata_props.add()
             prop.key = key
             prop.value = str(value)
-    
+
     onnx.save(model, onnx_path)
 ```
 
@@ -1295,397 +2187,276 @@ model:
   detection: true
   segmentation: false
   classification: false
-  split_decoder: true    # true = outputs need anchor decoding after dequantization
-                         # false = outputs are fully decoded boxes
-                         # See "Post-Processing & Split Decoder" section for details
   anchors:               # Per-level anchor boxes (pixels at input resolution)
     - [[35, 42], [57, 89], [125, 126]]
     - [[125, 126], [208, 260], [529, 491]]
 
 # Ultralytics model configuration
 model:
-  model_version: v8      # v5, v8, v11
+  model_version: v8      # v5, v8, v11, v26
   model_task: segment    # detect, segment
   model_size: n          # n (nano), s (small), m (medium), l (large), x (xlarge)
   detection: false
   segmentation: true
-  split_decoder: true    # true = split outputs for per-tensor INT8 quantization
-                         #   Detection: boxes, scores (2 outputs)
-                         #   Segmentation: boxes, scores, mask_coefficients, protos (4 outputs)
-                         # false = monolithic detection tensor
-                         # Default true for all quantized TFLite models
+  end2end: false         # true for YOLO26 end-to-end models with embedded NMS
 ```
 
 ### Outputs Section
 
-```yaml
-# ModelPack detection output example
-outputs:
-  - name: "output_0"
-    index: 0
-    output_index: 0
-    shape: [1, 40, 40, 54]
-    dshape:
-      - batch: 1
-      - height: 40
-      - width: 40
-      - num_anchors_x_features: 54   # 3 anchors × (5 + 13 classes)
-    dtype: float32
-    type: detection
-    decode: true
-    decoder: modelpack
-    quantization:
-      scale: 0.176
-      zero_point: 198
-      dtype: uint8
-    stride: [16, 16]
-    anchors:
-      - [0.054, 0.065]
-      - [0.089, 0.139]
-      - [0.195, 0.196]
+Each entry in the top-level `outputs[]` is a **logical output** following the two-layer model described in [Output Specification](#output-specification). See [Full Examples](#full-examples) for complete layouts per framework and task.
 
-# Ultralytics detection output example  
+Minimal Ultralytics detection (TFLite, flat):
+
+```yaml
 outputs:
-  - name: "output0"
-    index: 0
-    output_index: 0
-    shape: [1, 84, 8400]           # NCHW: [batch, 4+nc, num_boxes]
+  - name: boxes
+    type: boxes
+    shape: [1, 4, 8400]
     dshape:
       - batch: 1
-      - num_features: 84             # 4 box coords + 80 classes
+      - box_coords: 4
       - num_boxes: 8400
-    dtype: float32
-    type: detection
-    decode: true
+    dtype: int8
+    quantization: {scale: 0.00392, zero_point: 0, dtype: int8}
     decoder: ultralytics
-    quantization: null             # Float model
-    anchors: null                  # Anchor-free
-    score_format: per_class        # YOLOv8/v11/v26: class probabilities directly
+    encoding: direct
+    normalized: true
 
-# Ultralytics instance segmentation protos example
-  - name: "output1"
-    index: 1
-    output_index: 1
-    shape: [1, 32, 160, 160]       # NCHW: [batch, protos, H, W]
+  - name: scores
+    type: scores
+    shape: [1, 80, 8400]
     dshape:
       - batch: 1
-      - num_protos: 32
-      - height: 160
-      - width: 160
-    dtype: float32
-    type: protos
-    decode: true
+      - num_classes: 80
+      - num_boxes: 8400
+    dtype: int8
+    quantization: {scale: 0.00392, zero_point: 0, dtype: int8}
     decoder: ultralytics
-    quantization: null
-    anchors: null
-    score_format: null             # Not applicable to protos output
+    score_format: per_class
 ```
 
 ---
 
-## Split Hints
+## Appendix: Ultralytics YOLO Split Hints Reference
 
-Split hints encode model-specific knowledge about where natural quantization boundaries exist within output tensors. The training framework identifies these boundaries based on its knowledge of the model architecture; the converter decides whether to apply them.
+This appendix shows the exact `split_hints` that edgefirst-studio-ultralytics embeds in ONNX metadata for each supported YOLO version × task combination, using 80 COCO classes as the reference.
 
-### Purpose
+All versions share:
 
-When a single output tensor contains channels with different value distributions (e.g., [0,1]-bounded box coordinates alongside unbounded linear projections), a shared quantization scale degrades accuracy. Split hints tell converters where these natural boundaries exist so they can apply independent quantization scales to each region.
+- 3 FPN scales, strides [8, 16, 32]
+- Image size 640 → spatial positions: 80×80 + 40×40 + 20×20 = 8400
+- Segmentation adds 32 `mask_coefs` channels + `protos` output `[1, 32, 160, 160]` at stride 4
+- `input_dtype: uint8`, `output_dtype: int8`
+- Box coordinates are always 4 logical channels (post-decode)
 
-### Schema Governance
+Key differences:
 
-Hint types are defined in this schema documentation. The schema defines the vocabulary of hint types, their structure, and their semantics. Training frameworks populate hints according to this vocabulary. Converter UIs are built against the schema vocabulary, not against hints in any particular model.
+- **YOLOv5**: `anchors_per_cell: 3`, `encoding: anchor`, has `objectness` boundary, `score_format: obj_x_class`. Total logical channels per anchor: 4+1+nc [+32]. Monolithic output = (4+1+80)×3 = 255 channels for detect, (4+1+80+32)×3 = 351 for segment.
+- **YOLOv8 / YOLO11**: `encoding: dfl` (64 physical box channels, 4 logical), `score_format: per_class`. Total: 4+nc [+32]. So 84 for detect, 116 for segment.
+- **YOLO26**: `encoding: direct` (reg_max=1, 4 box channels), `score_format: per_class`. Total: 4+nc [+32]. So 84 for detect, 116 for segment. Same `split_hints` as v8/v11.
 
-### `split_hints` Array
-
-The `split_hints` field is a top-level array in `edgefirst.json`. Each element describes one hint.
-
-```yaml
-split_hints:
-  - type: string             # Hint type identifier (see Hint Types below)
-    target: string           # Output tensor name this hint applies to (e.g., "output0")
-    input_dtype: string      # Suggested input quantization dtype (e.g., "uint8")
-    output_dtype: string     # Suggested output quantization dtype (e.g., "int8")
-    description: string      # Human-readable purpose of this split
-    boundaries:              # Channel boundary definitions
-      - name: string         #   Region name (e.g., "detection", "mask_coefs")
-        channels: [int, int] #   Channel range [start, end) — exclusive end index
-```
-
-#### Field Reference
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `type` | string | Yes | Hint type identifier. Converters ignore types they do not understand |
-| `target` | string | Yes | Name of the output tensor this hint applies to (must match an entry in `outputs`) |
-| `input_dtype` | string | No | Suggested input quantization dtype (e.g., `uint8`, `float32`). Converter default, overridable by user |
-| `output_dtype` | string | No | Suggested output quantization dtype (e.g., `int8`, `float32`). Converter default, overridable by user |
-| `description` | string | No | Human-readable description of why this split boundary exists |
-| `boundaries` | array | Yes | Ordered list of channel regions within the target tensor |
-| `boundaries[].name` | string | Yes | Identifier for this region (used in split output naming) |
-| `boundaries[].channels` | [int, int] | Yes | Channel range as `[start, end)` with exclusive end index |
-
-### Behavior Rules
-
-- `split_hints` is an array — multiple hints can coexist (e.g., one per output tensor)
-- Each hint has a `type` field — converters **must ignore** types they do not understand (forward compatibility)
-- Converter UI presents all known split types from this schema as options
-- If the user enables a split type and matching hints exist in the model, the converter applies them
-- If the user enables a split type and no matching hints exist, the converter warns (not an error) and proceeds without splitting
-- Hints include suggested quantization defaults (`input_dtype`, `output_dtype`) that converters use as UI defaults; the user can override them
-- Boundary `channels` ranges must be non-overlapping and cover the full channel dimension of the target tensor when taken together
-
-### Hint Types
-
-#### `quantization_split`
-
-Channel boundaries within an output tensor that have different value distributions and benefit from independent quantization scales. The converter applies graph surgery to split the tensor at the specified boundaries, then quantizes each resulting tensor independently.
-
-**Example: Ultralytics segmentation model**
-
-The monolithic detection output `[1, 116, 8400]` contains 84 detection channels ([0,1]-bounded boxes + scores) and 32 mask coefficient channels (unbounded linear projection). Splitting at channel 84 allows independent quantization scales:
-
-```yaml
-split_hints:
-  - type: "quantization_split"
-    target: "output0"
-    input_dtype: "uint8"
-    output_dtype: "int8"
-    description: "Separate mask coefficients from detection channels for independent quantization"
-    boundaries:
-      - name: "detection"
-        channels: [0, 84]       # boxes (4) + class scores (80), [0,1] bounded
-      - name: "mask_coefs"
-        channels: [84, 116]     # mask coefficient linear projection, unbounded
-```
-
-#### `decoder_offload` (future)
-
-!!! note "Planned"
-    This hint type is reserved for future use. It is documented here to establish the schema vocabulary. Converters should ignore this type until a future schema revision provides the full specification.
-
-Boundary where decoder layers can be removed from the quantized graph and run externally in float32. This is relevant for models where the decoder (e.g., anchor decode, DFL softmax) suffers disproportionate quantization loss compared to the backbone and neck.
-
-#### `cpu_npu_boundary` (future)
-
-!!! note "Planned"
-    This hint type is reserved for future use. It is documented here to establish the schema vocabulary. Converters should ignore this type until a future schema revision provides the full specification.
-
-Suggested partition point for heterogeneous execution across CPU and NPU. The training framework identifies layers that are NPU-friendly (convolutions, dense) versus layers that benefit from CPU execution (complex activations, dynamic shapes).
-
-### Per-Task Split Recommendations
-
-Based on quantization experiments:
-
-| Task | Hints | Rationale |
-|------|-------|-----------|
-| **Detection** | No `split_hints` | Combined output `[1, nc+4, N]` quantizes effectively — boxes and scores are both in [0,1] range |
-| **Segmentation** | One `quantization_split` on output0 | Boxes+scores ([0,1] bounded) share a scale without penalty; mask coefficients (unbounded) need their own scale |
-| **Single-output (BEV)** | No `split_hints` | Single output with uniform value distribution |
-
----
-
-## Calibration Artifact
-
-Training frameworks produce a calibration artifact containing preprocessed, ready-to-consume calibration data. This artifact enables model-agnostic converters to perform quantization without knowing the model's preprocessing pipeline, input normalization, or data augmentation.
-
-### Rationale
-
-The training stage always generates calibration data because:
-
-- The model knows its own preprocessing (normalization, resizing, color space, [CameraAdaptor](cameraadaptor.md))
-- Multi-input models (e.g., camera + radar fusion) require model-specific preprocessing per input
-- Smart sample selection (percentile bounds, coverage optimization) runs once at training time
-- Converters become truly model-agnostic — they receive ready-to-consume tensors
-
-### Format
-
-Calibration data is stored in [safetensors](https://huggingface.co/docs/safetensors/) format with named tensors corresponding to model input names.
-
-### Naming Convention
-
-Calibration filenames encode the dataset and generation parameters for deterministic caching:
-
-```
-calibration-{dataset_id}-{param_hash}.safetensors
-```
-
-**Example:** `calibration-ds-2bcc-a1b2c3d4.safetensors`
-
-- `{dataset_id}` — Studio dataset label (e.g., `ds-2bcc`)
-- `{param_hash}` — Deterministic hash of the calibration generation parameters
-
-### Parameter Hash
-
-The parameter hash is computed from the inputs that determine calibration content. The hash is over the **parameters**, not the **content** — two trainers using the same parameters will produce the same hash even if they select different samples.
-
-Parameters included in the hash:
-
-| Parameter | Example | Why |
-|-----------|---------|-----|
-| Dataset ID | `ds-2bcc` | Which dataset |
-| Annotation set ID | `as-1a3f` | Which annotation version |
-| Validation group | `val` | Which split |
-| Image size | `640x640` | Resize target |
-| Preprocessing | `normalize_uint8`, `letterbox` | How pixels are transformed |
-| CameraAdaptor | `rgb`, `yuyv`, `grey` | Color space / channel config |
-| Calibration coverage | `10` | Percentage of validation set |
-| Selection algorithm | `greedy_coverage_v1` | Algorithm version (invalidates cache on algorithm changes) |
-
-The hash function and parameter serialization order are defined by each training framework but must be deterministic and consistent across runs.
-
-### Storage: Studio Snapshots
-
-Calibration artifacts are stored as **Studio snapshots**, not session artifacts. The filename is the cache key.
-
-**Trainer workflow:**
-
-1. Compute the parameter hash from calibration generation parameters
-2. Build the filename: `calibration-{dataset_id}-{param_hash}.safetensors`
-3. Look up the snapshot by filename via Studio API
-4. If the snapshot exists → download and use it (skip generation)
-5. If not → generate the calibration set, publish it as a snapshot with this filename
-
-This means a calibration set is generated **once** for a given set of parameters. Subsequent training runs with the same dataset, preprocessing, and coverage reuse the cached snapshot automatically.
-
-### Tensor Naming
-
-Tensor names in the safetensors file **must match the model's input tensor names**. Converters load all tensors by name and feed them to the calibration generator.
-
-#### Single-Input Model
-
-For models with a single image input (e.g., Ultralytics detection or segmentation):
-
-```
-calibration-ds-2bcc-a1b2c3d4.safetensors:
-  images: float32 [500, 3, 640, 640]    # [num_samples, channels, height, width]
-```
-
-- Tensor name `images` matches the model's input tensor name
-- Samples are preprocessed identically to training/inference (normalized to [0.0, 1.0], resized, CameraAdaptor applied)
-- Typical sample count: ~500 images (10% of validation set or 500, whichever is smaller)
-
-#### Multi-Input Model
-
-For models with multiple inputs (e.g., camera + radar fusion):
-
-```
-calibration-ds-2bcc-a1b2c3d4.safetensors:
-  camera: float32 [500, 3, 360, 640]    # [num_samples, channels, height, width]
-  radar:  float32 [500, 200, 128, 8]    # [num_samples, range_bins, doppler_bins, features]
-```
-
-- Each tensor name (`camera`, `radar`) matches the corresponding model input name
-- Each input is preprocessed according to its own pipeline (image normalization for camera, range-doppler processing for radar)
-- All inputs have the same number of samples (first dimension)
-
-### Converter Usage
-
-Converters consume the calibration artifact as follows:
-
-1. Read `edgefirst.json` from the training session to get the calibration filename
-2. Download the calibration snapshot by filename via Studio API
-3. Load all tensors using any safetensors-compatible library
-4. Match tensor names to model input names
-5. Iterate over samples (first dimension) to feed the calibration generator
-
-```python
-from safetensors import safe_open
-
-with safe_open(calibration_path, framework="numpy") as f:
-    tensor_names = f.keys()
-    num_samples = f.get_tensor(next(iter(tensor_names))).shape[0]
-
-    for i in range(num_samples):
-        feed_dict = {name: f.get_tensor(name)[i:i+1] for name in tensor_names}
-        yield feed_dict  # Feed to TFLiteConverter representative_dataset or equivalent
-```
-
----
-
-## Converter Traceability
-
-When a converter processes a model, it augments the existing `edgefirst.json` with a converter-specific section at the top level. This provides full traceability of all conversion steps applied to the model.
-
-### Rules
-
-- Converters **augment** — they never replace or remove existing fields in `edgefirst.json`
-- Each converter adds a top-level key named after itself (e.g., `"tflite_quantizer"`, `"neutron"`, `"ara2"`)
-- The converter section records conversion parameters, version, and any decisions made during conversion
-- Multiple converter sections can coexist when a model passes through a pipeline chain (e.g., TFLite Quantizer followed by Neutron Converter)
-
-### Converter Section Schema
-
-Each converter section is a free-form object, but should include at minimum:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `version` | string | Converter app version |
-| `timestamp` | string | ISO 8601 conversion timestamp |
-| `task` | string | Studio batch task ID for this conversion step (e.g., `bt-3a1f`) |
-
-Additional fields are converter-specific and documented by each converter app.
-
-### Example: Single Converter
-
-After TFLite quantization of an Ultralytics detection model:
+### A.1 YOLOv8n / YOLO11n Detection (80 classes)
 
 ```json
 {
-  "host": { "studio_server": "test.edgefirst.studio", "..." : "..." },
-  "model": { "..." : "..." },
-  "outputs": [ "..." ],
-  "split_hints": [ "..." ],
-
-  "tflite_quantizer": {
-    "version": "1.0.0",
-    "timestamp": "2026-03-20T15:30:00Z",
-    "task": "bt-3a1f",
-    "input_dtype": "uint8",
-    "output_dtype": "int8",
-    "calibration": "calibration-ds-2bcc-a1b2c3d4.safetensors",
-    "calibration_samples": 500,
-    "splits_applied": ["quantization_split"],
-    "quantizer": "mlir"
-  }
+  "split_hints": [
+    {
+      "type": "quantization_split",
+      "target": "output0",
+      "input_dtype": "uint8",
+      "output_dtype": "int8",
+      "strides": [8, 16, 32],
+      "description": "Detection head: boxes + scores",
+      "boundaries": [
+        {"name": "boxes", "channels": [0, 4]},
+        {"name": "scores", "channels": [4, 84], "activation": "sigmoid"}
+      ]
+    }
+  ]
 }
 ```
 
-### Example: Pipeline Chain
+YOLO11 uses the same `Detect` head architecture as YOLOv8 (anchor-free, DFL with reg_max=16). Split hints are identical.
 
-After TFLite quantization followed by Neutron conversion for i.MX95 deployment:
+| Boundary | Channels | Logical | Encoding | Activation | score_format |
+|---|---|---|---|---|---|
+| boxes | [0, 4) | 4 | dfl | — | — |
+| scores | [4, 84) | 80 | — | sigmoid | per_class |
+
+Monolithic output0 shape: `[1, 84, 8400]`
+
+### A.2 YOLOv8n / YOLO11n Segmentation (80 classes, 32 protos)
 
 ```json
 {
-  "host": { "..." : "..." },
-  "model": { "..." : "..." },
-  "outputs": [ "..." ],
-
-  "tflite_quantizer": {
-    "version": "1.0.0",
-    "timestamp": "2026-03-20T15:30:00Z",
-    "task": "bt-3a1f",
-    "input_dtype": "uint8",
-    "output_dtype": "int8",
-    "calibration": "calibration-ds-2bcc-a1b2c3d4.safetensors",
-    "calibration_samples": 500,
-    "splits_applied": [],
-    "quantizer": "mlir"
-  },
-
-  "neutron": {
-    "version": "2.1.0",
-    "timestamp": "2026-03-20T15:45:00Z",
-    "task": "bt-3a20",
-    "target": "imx95",
-    "neutron_version": "1.2.0",
-    "delegate": "neutron"
-  }
+  "split_hints": [
+    {
+      "type": "quantization_split",
+      "target": "output0",
+      "input_dtype": "uint8",
+      "output_dtype": "int8",
+      "strides": [8, 16, 32],
+      "description": "Segmentation head: boxes + scores + mask coefficients",
+      "boundaries": [
+        {"name": "boxes", "channels": [0, 4]},
+        {"name": "scores", "channels": [4, 84], "activation": "sigmoid"},
+        {"name": "mask_coefs", "channels": [84, 116]}
+      ]
+    }
+  ]
 }
 ```
 
-### Ordering
+`output1` (protos `[1, 32, 160, 160]`) is not included in split_hints — it's a separate ONNX output that does not need splitting.
 
-When a model passes through multiple converters, the chronological order is determined by the `timestamp` field in each converter section. The `task` field links each conversion step back to its Studio batch task (e.g., `bt-3a1f`) for full audit trail.
+| Boundary | Channels | Logical | Encoding | Activation | score_format |
+|---|---|---|---|---|---|
+| boxes | [0, 4) | 4 | dfl | — | — |
+| scores | [4, 84) | 80 | — | sigmoid | per_class |
+| mask_coefs | [84, 116) | 32 | — | — | — |
+
+Monolithic output0 shape: `[1, 116, 8400]`
+
+### A.3 YOLO26n Detection (80 classes)
+
+```json
+{
+  "split_hints": [
+    {
+      "type": "quantization_split",
+      "target": "output0",
+      "input_dtype": "uint8",
+      "output_dtype": "int8",
+      "strides": [8, 16, 32],
+      "description": "Detection head: boxes + scores",
+      "boundaries": [
+        {"name": "boxes", "channels": [0, 4]},
+        {"name": "scores", "channels": [4, 84], "activation": "sigmoid"}
+      ]
+    }
+  ]
+}
+```
+
+YOLO26 uses `reg_max=1`, producing 4-channel boxes directly (no DFL distribution). The logical split_hints are identical to YOLOv8/v11 — the `encoding` difference (`direct` vs `dfl`) is captured in the compiled `outputs[]`, not in `split_hints`. End-to-end mode (`model.end2end: true`) is incompatible with `split_hints`.
+
+| Boundary | Channels | Logical | Encoding | Activation | score_format |
+|---|---|---|---|---|---|
+| boxes | [0, 4) | 4 | direct | — | — |
+| scores | [4, 84) | 80 | — | sigmoid | per_class |
+
+Monolithic output0 shape: `[1, 84, 8400]`
+
+### A.4 YOLO26n Segmentation (80 classes, 32 protos)
+
+```json
+{
+  "split_hints": [
+    {
+      "type": "quantization_split",
+      "target": "output0",
+      "input_dtype": "uint8",
+      "output_dtype": "int8",
+      "strides": [8, 16, 32],
+      "description": "Segmentation head: boxes + scores + mask coefficients",
+      "boundaries": [
+        {"name": "boxes", "channels": [0, 4]},
+        {"name": "scores", "channels": [4, 84], "activation": "sigmoid"},
+        {"name": "mask_coefs", "channels": [84, 116]}
+      ]
+    }
+  ]
+}
+```
+
+| Boundary | Channels | Logical | Encoding | Activation | score_format |
+|---|---|---|---|---|---|
+| boxes | [0, 4) | 4 | direct | — | — |
+| scores | [4, 84) | 80 | — | sigmoid | per_class |
+| mask_coefs | [84, 116) | 32 | — | — | — |
+
+Monolithic output0 shape: `[1, 116, 8400]`
+
+### A.5 YOLOv5n Detection (80 classes)
+
+```json
+{
+  "split_hints": [
+    {
+      "type": "quantization_split",
+      "target": "output0",
+      "input_dtype": "uint8",
+      "output_dtype": "int8",
+      "strides": [8, 16, 32],
+      "anchors_per_cell": 3,
+      "description": "Detection head: boxes + objectness + scores (anchor-based)",
+      "boundaries": [
+        {"name": "boxes", "channels": [0, 4]},
+        {"name": "objectness", "channels": [4, 5], "activation": "sigmoid"},
+        {"name": "scores", "channels": [5, 85], "activation": "sigmoid"}
+      ]
+    }
+  ]
+}
+```
+
+YOLOv5 is anchor-based with 3 anchors per cell. Per-scale physical channel counts are multiplied by `anchors_per_cell`: boxes=3×4=12, objectness=3×1=3, scores=3×80=240. Total per anchor: 4+1+80=85, total per cell: 85×3=255. Concrete anchor dimensions are in `model.anchors`.
+
+| Boundary | Channels | Logical | ×anchors | Encoding | Activation | score_format |
+|---|---|---|---|---|---|---|
+| boxes | [0, 4) | 4 | 12 | anchor | — | — |
+| objectness | [4, 5) | 1 | 3 | — | sigmoid | — |
+| scores | [5, 85) | 80 | 240 | — | sigmoid | obj_x_class |
+
+Monolithic output0 shape: `[1, 255, 8400]`
+
+### A.6 YOLOv5n Segmentation (80 classes, 32 protos)
+
+```json
+{
+  "split_hints": [
+    {
+      "type": "quantization_split",
+      "target": "output0",
+      "input_dtype": "uint8",
+      "output_dtype": "int8",
+      "strides": [8, 16, 32],
+      "anchors_per_cell": 3,
+      "description": "Segmentation head: boxes + objectness + scores + mask coefficients (anchor-based)",
+      "boundaries": [
+        {"name": "boxes", "channels": [0, 4]},
+        {"name": "objectness", "channels": [4, 5], "activation": "sigmoid"},
+        {"name": "scores", "channels": [5, 85], "activation": "sigmoid"},
+        {"name": "mask_coefs", "channels": [85, 117]}
+      ]
+    }
+  ]
+}
+```
+
+| Boundary | Channels | Logical | ×anchors | Encoding | Activation | score_format |
+|---|---|---|---|---|---|---|
+| boxes | [0, 4) | 4 | 12 | anchor | — | — |
+| objectness | [4, 5) | 1 | 3 | — | sigmoid | — |
+| scores | [5, 85) | 80 | 240 | — | sigmoid | obj_x_class |
+| mask_coefs | [85, 117) | 32 | 96 | — | — | — |
+
+Monolithic output0 shape: `[1, 351, 8400]`
+
+### A.7 Summary Table
+
+| Model | Task | Boundaries | output0 channels | anchors_per_cell | encoding | score_format |
+|---|---|---|---|---|---|---|
+| YOLOv5 | detect | boxes, objectness, scores | 255 (85×3) | 3 | anchor | obj_x_class |
+| YOLOv5 | segment | boxes, objectness, scores, mask_coefs | 351 (117×3) | 3 | anchor | obj_x_class |
+| YOLOv8 | detect | boxes, scores | 84 | 1 | dfl | per_class |
+| YOLOv8 | segment | boxes, scores, mask_coefs | 116 | 1 | dfl | per_class |
+| YOLO11 | detect | boxes, scores | 84 | 1 | dfl | per_class |
+| YOLO11 | segment | boxes, scores, mask_coefs | 116 | 1 | dfl | per_class |
+| YOLO26 | detect | boxes, scores | 84 | 1 | direct | per_class |
+| YOLO26 | segment | boxes, scores, mask_coefs | 116 | 1 | direct | per_class |
+
+All models: 3 scales, strides [8, 16, 32], 8400 spatial positions at 640px input.
 
 ---
 

--- a/docs/models/ultralytics/quantize.md
+++ b/docs/models/ultralytics/quantize.md
@@ -29,7 +29,7 @@ YOLOv8n on COCO val2017 (5000 images, 80 classes, 640x640 RGB input). Validated 
 |-------|-------------|-------------------|--------------|---------------------|
 | TFLite INT8 (EdgeFirst, 10% calibration) | 41.68% | 27.83% | 40.37% | 24.62% |
 
-EdgeFirst Studio INT8 models use split decoder outputs and [0,1] normalized box coordinates for both detection and segmentation. Detection models produce 2 outputs (boxes, scores); segmentation models produce 4 (boxes, scores, mask_coefficients, protos). See [Model Metadata](../metadata.md#post-processing-two-layer-outputs) for details.
+EdgeFirst Studio quantized models use split decoder outputs and [0,1] normalized box coordinates for both detection and segmentation. Detection models produce 2 outputs (boxes, scores); segmentation models produce 4 (boxes, scores, mask_coefs, protos). See [Model Metadata](../metadata.md#post-processing-two-layer-outputs) for details.
 
 ### Output Format
 

--- a/docs/models/ultralytics/quantize.md
+++ b/docs/models/ultralytics/quantize.md
@@ -29,7 +29,7 @@ YOLOv8n on COCO val2017 (5000 images, 80 classes, 640x640 RGB input). Validated 
 |-------|-------------|-------------------|--------------|---------------------|
 | TFLite INT8 (EdgeFirst, 10% calibration) | 41.68% | 27.83% | 40.37% | 24.62% |
 
-EdgeFirst Studio INT8 models use split decoder outputs and [0,1] normalized box coordinates for both detection and segmentation. Detection models produce 2 outputs (boxes, scores); segmentation models produce 4 (boxes, scores, mask_coefficients, protos). See [Model Metadata](../metadata.md#post-processing-split-decoder) for details.
+EdgeFirst Studio INT8 models use split decoder outputs and [0,1] normalized box coordinates for both detection and segmentation. Detection models produce 2 outputs (boxes, scores); segmentation models produce 4 (boxes, scores, mask_coefficients, protos). See [Model Metadata](../metadata.md#post-processing-two-layer-outputs) for details.
 
 ### Output Format
 


### PR DESCRIPTION
## Summary

- Introduces `schema_version: 2` with a **logical/physical two-layer output model**. Each entry in `outputs[]` is a logical output; converters that further split the tensor (ARA-2 xy/wh, Hailo per-scale) describe their decomposition as physical `outputs[]` children. One level of nesting only.
- Formalizes the **split_hints lifecycle**: input-only metadata in ONNX/SavedModel, replaced by the compiled `outputs[]` array post-conversion. Split_hints schema expanded with `strides`, `anchors_per_cell`, and per-boundary `activation`.
- Removes redundant fields subsumed by the two-layer structure: `model.split_decoder`, `decode: bool`, `index`, `output_index`. Renames `mask_coefficients` → `mask_coefs`.
- Adds explicit `encoding: dfl | direct | anchor` on `boxes` outputs (replaces brittle channel-count heuristic), `activation_applied` / `activation_required` on physical children, `scale_index` per-scale.
- New sections: **HAL Decoder Algorithm** (with pseudocode + merge strategy), **Logical vs Physical Field Placement**, **Architecture Survey**, **8 Full Examples** (ModelPack seg/det, Ultralytics TFLite/ARA-2/Hailo, YOLO26 end-to-end, YOLOv5 anchor, DETR), **Ultralytics Split Hints Appendix** (A.1–A.7), and **Kinara/Hailo terminology mapping**.
- `dshape` retained (critical for NHWC vs NCHW disambiguation); rationale inlined at field introduction.
- Fixes broken anchor in `docs/models/ultralytics/quantize.md`.

## Test plan

- [ ] Preview rendered MkDocs output — confirm all internal anchors (`#post-processing-two-layer-outputs`, `#hal-nms-field`, `#validation-parameters`, `#merge-strategy`, `#architecture-survey`, `#output-specification`) resolve
- [ ] Verify the 8 Full Examples are internally consistent (shapes ↔ dshape ↔ encoding)
- [ ] Cross-check the Ultralytics Split Hints appendix (A.1–A.7) against `_build_edgefirst_config()` output in `edgefirst-studio-ultralytics`
- [ ] Confirm no dangling references to removed fields (`split_decoder`, `decode: true/false`, `index`, `output_index`, `mask_coefficients`) remain in the doc
- [ ] Spot-check that ModelPack grid output semantics are preserved (`type: detection` still valid for anchor-grid outputs)
- [ ] Spot-check that YOLO26 end-to-end example renders and is unambiguous about the absent root-level `nms` field