### PR TITLE
DE-2614: Document Enable Training, Use Default Weights, and clone session; fix table formatting

### DIFF
--- a/docs/datasets/format/conversion.md
+++ b/docs/datasets/format/conversion.md
@@ -139,7 +139,7 @@ result = duckdb.sql("""
 ### Column Name Mapping
 
 | Arrow / Parquet column | JSON field | Notes |
-|------------------------|------------|-------|
+| ---------------------- | ---------- | ----- |
 | `label` | `label_name` | Historical naming difference |
 | `group` | `group_name` | Historical naming difference |
 | `object_id` | `object_id` | 2026.04 uses `object_id` (not legacy `object_reference`) |
@@ -237,7 +237,7 @@ df.write_ipc("annotations.arrow")       # Arrow IPC
 ### Key Conversions Summary
 
 | # | Conversion | Direction |
-|---|------------|-----------|
+| --- | ---------- | --------- |
 | 1 | **Unnest**: one row per annotation | JSON to DataFrame |
 | 2 | **Column names**: `label_name` to `label`, `group_name` to `group` | JSON to DataFrame |
 | 3 | **Polygon**: `[[x,y],...]` point pairs to `[x,y,x,y,...]` interleaved | JSON to DataFrame |

--- a/docs/datasets/format/formats.md
+++ b/docs/datasets/format/formats.md
@@ -6,8 +6,8 @@ model concern.
 
 ## Format Tiers
 
-| | Arrow IPC | Parquet | JSON |
-|---|-----------|---------|------|
+|  | Arrow IPC | Parquet | JSON |
+| --- | --------- | ------- | ---- |
 | **Extension** | `.arrow` | `.parquet` | `.json` |
 | **Use Case** | Local ML training, fast random access | Transfer, cloud storage, interop | Human-readable, API exchange |
 | **Structure** | Flat columnar (one row per annotation) | Flat columnar (one row per annotation) | Nested (sample with annotations array) |
@@ -108,7 +108,7 @@ archival, bandwidth-constrained transfers.
 EdgeFirst uses the following Parquet defaults:
 
 | Setting | Value | Rationale |
-|---------|-------|-----------|
+| ------- | ----- | --------- |
 | Compression | ZSTD (level 3) | Best compression/speed trade-off for transfer |
 | Row group size | 64K rows or 256 MB | Balance between random access and compression |
 | Page encoding | Parquet v2 (data page v2) | Better compression, widely supported |

--- a/docs/models/metadata.md
+++ b/docs/models/metadata.md
@@ -25,14 +25,14 @@ schema_version: 2
 EdgeFirst models from the [Model Zoo](index.md) (including [ModelPack](modelpack/index.md) and [Ultralytics](ultralytics/index.md)) embed metadata in format-specific locations:
 
 | Format | Metadata Location | Config Format | Labels |
-|--------|-------------------|---------------|--------|
+| ------ | ----------------- | ------------- | ------ |
 | TFLite | ZIP archive (associated files) | `edgefirst.json` | `labels.txt` |
 | ONNX | Custom metadata properties | `edgefirst` (JSON) | `labels` (JSON array) |
 
 ### Supported Training Frameworks
 
 | Framework | Decoder | Architecture | Use Case |
-|-----------|---------|--------------|----------|
+| --------- | ------- | ------------ | -------- |
 | [ModelPack](modelpack/index.md) | `modelpack` | Anchor-based YOLO | Semantic segmentation, detection |
 | [Ultralytics](ultralytics/index.md) | `ultralytics` | Anchor-free DFL (YOLOv5/v8/v11/v26) | Instance segmentation, detection |
 
@@ -53,7 +53,7 @@ One of the most critical aspects of production ML systems is **traceability** �
 EdgeFirst metadata provides complete traceability through these key fields:
 
 | Field | Location | Purpose |
-|-------|----------|---------|
+| ----- | -------- | ------- |
 | `studio_server` | `host.studio_server` | Full hostname of [EdgeFirst Studio](../studio/index.md) instance (e.g., test.edgefirst.studio) |
 | `project_id` | `host.project_id` | Project ID for constructing Studio URLs |
 | `session_id` | `host.session` | [Training session](../studio/models.md#training-sessions) ID for accessing logs, metrics, artifacts |
@@ -420,7 +420,7 @@ Each entry in the top-level `outputs[]` array is a **logical output**. A logical
 Logical output types used across frameworks:
 
 | Type | Description | Typical Shape (logical) |
-|---|---|---|
+| ---- | ----------- | ----------------------- |
 | `boxes` | Bounding box coordinates | `[1, 4, num_boxes]` or `[1, reg_max×4, num_boxes]` for DFL |
 | `scores` | Per-class or class-aggregate scores | `[1, num_classes, num_boxes]` |
 | `objectness` | Objectness scores (YOLOv5-style `obj_x_class`) | `[1, anchors_per_cell, num_boxes]` |
@@ -436,7 +436,7 @@ Logical output types used across frameworks:
 Physical-child subtypes (appear only inside `outputs[]` children):
 
 | Subtype | When Used | Description |
-|---|---|---|
+| ------- | --------- | ----------- |
 | `boxes_xy` | ARA-2 channel sub-split | xy coordinates split for independent INT16 quantization |
 | `boxes_wh` | ARA-2 channel sub-split | wh coordinates split for independent INT16 quantization |
 | *(same as parent)* | Per-scale split | Each FPN scale produces one child with the parent's type |
@@ -459,7 +459,7 @@ outputs:
 **Standard dimension names:**
 
 | Name | Description |
-|---|---|
+| ---- | ----------- |
 | `batch` | Batch size (typically 1 for inference) |
 | `height` | Spatial height |
 | `width` | Spatial width |
@@ -478,7 +478,7 @@ outputs:
 The `encoding` field on a `boxes` logical output tells the HAL how to interpret the raw channel data after dequantization.
 
 | Value | Channels | Description | Decode Step |
-|---|---|---|---|
+| ----- | -------- | ----------- | ----------- |
 | `dfl` | `reg_max × 4` (typically 64) | Distribution Focal Loss encoding. Each coordinate is a probability distribution over `reg_max` bins. | Softmax over each `reg_max` group, then weighted sum → 4 coordinates. Common in YOLOv8, YOLO11. |
 | `direct` | 4 | Direct coordinate values — already decoded. | Dequantize only. Common in YOLO26 (reg_max=1), ARA-2 post-split. |
 | `anchor` | `anchors_per_cell × 4` | Anchor-based grid offsets. Each group of 4 is (tx, ty, tw, th) requiring sigmoid + anchor-scale transform. | Sigmoid + anchor transform per grid cell. Common in YOLOv5, SSD MobileNet, ModelPack. |
@@ -490,7 +490,7 @@ The `encoding` field on a `boxes` logical output tells the HAL how to interpret 
 The `score_format` field on a `scores` logical output disambiguates YOLOv5's `obj_x_class` encoding from the default per-class encoding used by YOLOv8/v11/v26:
 
 | Value | Description | Architecture |
-|---|---|---|
+| ----- | ----------- | ------------ |
 | `per_class` | Each anchor outputs `[nc]` class probabilities directly | YOLOv8, YOLO11, YOLO26, default |
 | `obj_x_class` | Each anchor outputs `[nc]` class probabilities; a separate `objectness` logical output provides `[1]` per anchor. Final detection confidence = `objectness × class_score` per anchor | YOLOv5 |
 
@@ -577,7 +577,7 @@ The HAL infers the merge strategy from child fields: presence of `stride` → sp
 ### Direct Path Examples
 
 | Target | Logical Type | Children Types | Direct Decoder |
-|---|---|---|---|
+| ------ | ------------ | -------------- | -------------- |
 | ARA-2 | `boxes` | `boxes_xy`, `boxes_wh` | `box_assembly` — INT16 dequant + dist2bbox in one pass |
 | Hailo | `scores` | `scores` ×3 (per-scale) | Per-scale sigmoid already applied, just spatial concat |
 
@@ -612,7 +612,7 @@ For detailed specifications, see the [ONNX QuantizeLinear operator](https://onnx
 ### Quantization Object Schema
 
 | Field | Type | Required | Description |
-|---|---|---|---|
+| ----- | ---- | -------- | ----------- |
 | `scale` | float or \[float\] | Yes | Scale factor(s). Scalar = per-tensor, array = per-channel |
 | `zero_point` | int or \[int\] | No | Zero point offset(s). Omit for symmetric quantization (implies 0) |
 | `axis` | int | When per-channel | Tensor dimension index that the scale/zero_point arrays correspond to |
@@ -680,7 +680,7 @@ def dequantize(raw_output: np.ndarray, quantization: dict) -> np.ndarray:
 ### Framework Conventions
 
 | Framework | Per-Tensor | Per-Channel | Symmetric | Axis Field |
-|---|---|---|---|---|
+| --------- | ---------- | ----------- | --------- | ---------- |
 | ONNX | Scalar scale | 1-D scale + `axis` | Implicit (zero_point=0) | `axis` (default 1) |
 | TFLite/LiteRT | Scalar (1-element array) | 1-D scale + `quantized_dimension` | Implicit (zero_point=0 for weights) | `quantized_dimension` |
 | TensorRT | Scalar scale | Per-channel scale | Always symmetric | Output channel axis |
@@ -693,7 +693,7 @@ Some NPU toolchains use different terminology internally. Converters translate a
 **Kinara ARA-2** (ioparams.json, qmode 9 — asymmetric):
 
 | Kinara term | edgefirst.json term | Notes |
-|---|---|---|
+| ----------- | ------------------- | ----- |
 | `outputScale` / `outputQn` | `scale` | Identical value for qmode 9. For symmetric qmodes (0–3), Kinara's `qn` is 1/scale — but the ARA-2 converter always uses qmode 9 |
 | `offset` | `zero_point` | Identical value |
 | `bpp` + `isSigned` | `dtype` | `bpp=1, signed` → `int8`, `bpp=2, unsigned` → `uint16`, etc. |
@@ -701,7 +701,7 @@ Some NPU toolchains use different terminology internally. Converters translate a
 **Hailo** (HEF quantization info):
 
 | Hailo term | edgefirst.json term |
-|---|---|
+| ---------- | ------------------- |
 | `qp_scale` | `scale` |
 | `qp_zp` | `zero_point` |
 
@@ -712,7 +712,7 @@ Some NPU toolchains use different terminology internally. Converters translate a
 Deep learning frameworks use different memory layouts for tensor data. The metadata accurately reflects each format's native layout:
 
 | Format | Data Layout | Shape Convention | Example (batch=1, 640x640, RGB) |
-|--------|-------------|------------------|----------------------------------|
+| ------ | ----------- | ---------------- | ------------------------------- |
 | TFLite | **NHWC** | `[batch, height, width, channels]` | `[1, 640, 640, 3]` |
 | ONNX | **NCHW** | `[batch, channels, height, width]` | `[1, 3, 640, 640]` |
 
@@ -791,7 +791,7 @@ For quantized models (INT8), the quantization parameters handle the scaling inte
 The `cameraadaptor` field specifies the expected input format for the model. See [Camera Adaptor](cameraadaptor.md) for details on how this enables models to consume native camera formats without runtime conversion.
 
 | Value | Description | Channel Order |
-|---|---|---|
+| ----- | ----------- | ------------- |
 | `rgb` | Standard RGB | Red, Green, Blue |
 | `bgr` | OpenCV default | Blue, Green, Red |
 | `rgba` | RGB with alpha | Red, Green, Blue, Alpha |
@@ -816,7 +816,7 @@ The `validation` section records the recommended settings based on how the model
 ### Parameter Semantics
 
 | Parameter | Description | Default | Override at Runtime? |
-|---|---|---|---|
+| --------- | ----------- | ------- | -------------------- |
 | `iou` | NMS IoU threshold | `0.7` | Yes |
 | `score` | NMS confidence score threshold | `0.001` | Yes |
 | `nms` | NMS algorithm | *(not set)* | See below |
@@ -835,7 +835,7 @@ Both produce post-NMS output in `[x1, y1, x2, y2, conf, class, ...]` format. Det
 ### Allowed `nms` Values
 
 | Value | Description |
-|---|---|
+| ----- | ----------- |
 | `none` | No external NMS. For models with embedded NMS — either architectural end-to-end (YOLO26) or engine-embedded (ONNX/TRT/TFLite with NMS ops appended). Supports both detection and segmentation |
 | `numpy` | NumPy-based NMS implementation (default fallback) |
 | `hal` | EdgeFirst HAL decoder NMS |
@@ -849,7 +849,7 @@ When `--override` is set, the validator reads `validation.nms` from the model me
 The `normalized` field on `boxes` and `detections` outputs specifies the coordinate format:
 
 | Value | Description | Coordinate Range |
-|---|---|---|
+| ----- | ----------- | ---------------- |
 | `true` | Normalized coordinates relative to model input dimensions | `[0.0, 1.0]` |
 | `false` | Pixel coordinates relative to model input (letterboxed frame) | `[0, width]` / `[0, height]` |
 
@@ -967,11 +967,11 @@ x2y2 = anchor_points + rb
 **Version differences** — all Ultralytics versions use the same anchor-free `Detect` class. Differences are in backbone architecture:
 
 | Version | Backbone Blocks | Classification Head |
-|---|---|---|
-| YOLOv5  | C3              | Conv→Conv→Conv2d        |
-| YOLOv8  | C2f             | Conv→Conv→Conv2d        |
-| YOLO11  | C3k2, C2PSA     | DWConv→Conv (efficient) |
-| YOLO26  | C3k2, A2C2f     | DWConv→Conv (efficient) |
+| ------- | --------------- | ------------------- |
+| YOLOv5 | C3 | Conv→Conv→Conv2d |
+| YOLOv8 | C2f | Conv→Conv→Conv2d |
+| YOLO11 | C3k2, C2PSA | DWConv→Conv (efficient) |
+| YOLO26 | C3k2, A2C2f | DWConv→Conv (efficient) |
 
 ### Decoder Version Field
 
@@ -986,7 +986,7 @@ decoder_version: yolov8    # Traditional model requiring external NMS
 **Supported values:**
 
 | Value | Architecture | NMS Handling |
-|---|---|---|
+| ----- | ------------ | ------------ |
 | `yolov5` | YOLOv5 | External NMS required |
 | `yolov8` | YOLOv8 | External NMS required |
 | `yolo11` | YOLO11 | External NMS required |
@@ -1018,7 +1018,7 @@ nms: class_aware       # Only suppress boxes with the same class label
 ```
 
 | Value | Behavior |
-|---|---|
+| ----- | -------- |
 | `class_agnostic` | Suppress overlapping boxes regardless of class label (default) |
 | `class_aware` | Only suppress boxes that share the same class AND overlap |
 
@@ -1087,7 +1087,7 @@ split_hints:
 ### Fields
 
 | Field | Type | Required | Description |
-|---|---|---|---|
+| ----- | ---- | -------- | ----------- |
 | `type` | string | Yes | Hint type identifier. Converters ignore types they do not understand |
 | `target` | string | Yes | Name of the output tensor this hint applies to |
 | `input_dtype` | string | No | Suggested input quantization dtype (e.g., `uint8`) |
@@ -1100,7 +1100,7 @@ split_hints:
 ### Boundary Fields
 
 | Field | Type | Required | Description |
-|---|---|---|---|
+| ----- | ---- | -------- | ----------- |
 | `name` | string | Yes | Free-form semantic label (e.g., `boxes`, `scores`, `mask_coefs`, `landmarks`, `objectness`, `confidence`) |
 | `channels` | [int, int] | Yes | Channel range `[start, end)` in the logical output. Always post-decode, post-DFL logical channels (e.g., 4 for decoded box coords, not 64 for DFL-encoded) |
 | `activation` | string | No | Post-activation to apply (`sigmoid`, `softmax`, `tanh`). Converters that can fuse it into the NPU do so; others note it for the HAL |
@@ -1151,7 +1151,7 @@ split_hints:
 Based on quantization experiments:
 
 | Task | Hints | Rationale |
-|---|---|---|
+| ---- | ----- | --------- |
 | **Detection** | One `quantization_split` on output0 with `boxes` + `scores` boundaries | Per-component scales improve INT8 precision; boxes and scores have different distributions |
 | **Segmentation** | One `quantization_split` on output0 with `boxes` + `scores` + `mask_coefs` boundaries | Mask coefficients (unbounded) especially benefit from their own scale |
 | **End-to-end (YOLO26 `end2end: true`)** | None | Output is already post-NMS; nothing to split |
@@ -1164,7 +1164,7 @@ Based on quantization experiments:
 Coverage of the two-layer output model across the detection, segmentation, and end-to-end architectures currently supported by the EdgeFirst ecosystem. The list grows as new architectures are onboarded — the two-layer model is general and accommodates additional families (SCRFD, EfficientDet, YOLACT, DETR variants, etc.) without schema changes.
 
 | Architecture | Scales | Heads | Monolithic in ONNX? | Two-Layer Mapping |
-|---|---|---|---|---|
+| ------------ | ------ | ----- | ------------------- | ----------------- |
 | YOLOv8 / YOLO11 detection | 3 | 2 (box, score) | Yes | 2 logical (`boxes`, `scores`), optional per-scale or xy/wh children |
 | YOLOv8 / YOLO11 segmentation | 3 | 3 + protos | Yes | 3 logical w/ children + 1 direct (`protos`) |
 | YOLO26 detection | 3 | 2 (box, score) | Yes | 2 logical, optional children — `encoding: direct` |
@@ -1664,7 +1664,7 @@ The parameter hash is computed from the inputs that determine calibration conten
 Parameters included in the hash:
 
 | Parameter | Example | Why |
-|---|---|---|
+| --------- | ------- | --- |
 | Dataset ID | `ds-2bcc` | Which dataset |
 | Annotation set ID | `as-1a3f` | Which annotation version |
 | Validation group | `val` | Which split |
@@ -1761,7 +1761,7 @@ When a converter processes a model, it augments the existing `edgefirst.json` wi
 Each converter section is a free-form object, but should include at minimum:
 
 | Field | Type | Description |
-|---|---|---|
+| ----- | ---- | ----------- |
 | `version` | string | Converter app version |
 | `timestamp` | string | ISO 8601 conversion timestamp |
 | `task` | string | Studio batch task ID for this conversion step (e.g., `bt-3a1f`) |
@@ -1839,7 +1839,7 @@ When a model passes through multiple converters, the chronological order is dete
 ONNX models exported from [ModelPack](modelpack/index.md) or [Ultralytics](ultralytics/index.md) include additional official metadata fields:
 
 | Field | ModelPack Value | Ultralytics Value | Purpose |
-|---|---|---|---|
+| ----- | --------------- | ----------------- | ------- |
 | `producer_name` | "EdgeFirst ModelPack" | "EdgeFirst Ultralytics" | Identifies producing framework |
 | `producer_version` | Package version | Package version | Version tracking |
 | `graph.name` | Model name | Model name | Graph identification |
@@ -1848,7 +1848,7 @@ ONNX models exported from [ModelPack](modelpack/index.md) or [Ultralytics](ultra
 Custom metadata properties (all string values):
 
 | Key | Content | Purpose |
-|---|---|---|
+| --- | ------- | ------- |
 | `edgefirst` | Full config as JSON | Complete configuration |
 | `name` | Model name | Quick access (no JSON parsing) |
 | `description` | Model description | Quick access |
@@ -2243,7 +2243,7 @@ Key differences:
 YOLO11 uses the same `Detect` head architecture as YOLOv8 (anchor-free, DFL with reg_max=16). Split hints are identical.
 
 | Boundary | Channels | Logical | Encoding | Activation | score_format |
-|---|---|---|---|---|---|
+| -------- | -------- | ------- | -------- | ---------- | ------------ |
 | boxes | [0, 4) | 4 | dfl | — | — |
 | scores | [4, 84) | 80 | — | sigmoid | per_class |
 
@@ -2274,7 +2274,7 @@ Monolithic output0 shape: `[1, 84, 8400]`
 `output1` (protos `[1, 32, 160, 160]`) is not included in split_hints — it's a separate ONNX output that does not need splitting.
 
 | Boundary | Channels | Logical | Encoding | Activation | score_format |
-|---|---|---|---|---|---|
+| -------- | -------- | ------- | -------- | ---------- | ------------ |
 | boxes | [0, 4) | 4 | dfl | — | — |
 | scores | [4, 84) | 80 | — | sigmoid | per_class |
 | mask_coefs | [84, 116) | 32 | — | — | — |
@@ -2305,7 +2305,7 @@ Monolithic output0 shape: `[1, 116, 8400]`
 YOLO26 uses `reg_max=1`, producing 4-channel boxes directly (no DFL distribution). The logical split_hints are identical to YOLOv8/v11 — the `encoding` difference (`direct` vs `dfl`) is captured in the compiled `outputs[]`, not in `split_hints`. End-to-end mode (`model.end2end: true`) is incompatible with `split_hints`.
 
 | Boundary | Channels | Logical | Encoding | Activation | score_format |
-|---|---|---|---|---|---|
+| -------- | -------- | ------- | -------- | ---------- | ------------ |
 | boxes | [0, 4) | 4 | direct | — | — |
 | scores | [4, 84) | 80 | — | sigmoid | per_class |
 
@@ -2334,7 +2334,7 @@ Monolithic output0 shape: `[1, 84, 8400]`
 ```
 
 | Boundary | Channels | Logical | Encoding | Activation | score_format |
-|---|---|---|---|---|---|
+| -------- | -------- | ------- | -------- | ---------- | ------------ |
 | boxes | [0, 4) | 4 | direct | — | — |
 | scores | [4, 84) | 80 | — | sigmoid | per_class |
 | mask_coefs | [84, 116) | 32 | — | — | — |
@@ -2367,7 +2367,7 @@ Monolithic output0 shape: `[1, 116, 8400]`
 YOLOv5 is anchor-based with 3 anchors per cell. Per-scale physical channel counts are multiplied by `anchors_per_cell`: boxes=3×4=12, objectness=3×1=3, scores=3×80=240. Total per anchor: 4+1+80=85, total per cell: 85×3=255. Concrete anchor dimensions are in `model.anchors`.
 
 | Boundary | Channels | Logical | ×anchors | Encoding | Activation | score_format |
-|---|---|---|---|---|---|---|
+| -------- | -------- | ------- | -------- | -------- | ---------- | ------------ |
 | boxes | [0, 4) | 4 | 12 | anchor | — | — |
 | objectness | [4, 5) | 1 | 3 | — | sigmoid | — |
 | scores | [5, 85) | 80 | 240 | — | sigmoid | obj_x_class |
@@ -2399,7 +2399,7 @@ Monolithic output0 shape: `[1, 255, 8400]`
 ```
 
 | Boundary | Channels | Logical | ×anchors | Encoding | Activation | score_format |
-|---|---|---|---|---|---|---|
+| -------- | -------- | ------- | -------- | -------- | ---------- | ------------ |
 | boxes | [0, 4) | 4 | 12 | anchor | — | — |
 | objectness | [4, 5) | 1 | 3 | — | sigmoid | — |
 | scores | [5, 85) | 80 | 240 | — | sigmoid | obj_x_class |
@@ -2410,7 +2410,7 @@ Monolithic output0 shape: `[1, 351, 8400]`
 ### A.7 Summary Table
 
 | Model | Task | Boundaries | output0 channels | anchors_per_cell | encoding | score_format |
-|---|---|---|---|---|---|---|
+| ----- | ---- | ---------- | ---------------- | ---------------- | -------- | ------------ |
 | YOLOv5 | detect | boxes, objectness, scores | 255 (85×3) | 3 | anchor | obj_x_class |
 | YOLOv5 | segment | boxes, objectness, scores, mask_coefs | 351 (117×3) | 3 | anchor | obj_x_class |
 | YOLOv8 | detect | boxes, scores | 84 | 1 | dfl | per_class |

--- a/docs/models/modelpack/index.md
+++ b/docs/models/modelpack/index.md
@@ -82,7 +82,10 @@ ModelPack can be trained now in EdgeFirst Studio using a Graphical User Interfac
         7. **Space to Depth**: This feature enables the Space to Depth Transformation to the input in order to reduce model complexity on higher resolutions
         8. **Split Decoder**: Remove the decoder from the model and use a very optimized one from EdgeFirst.  This feature is very useful when the location of the boxes has to be precise (0-offset)
     7. **Training Parameters**: In this section the user is able to specify the number of epochs to train the model as well as the batch size.  Remember the larger the input resolution the smaller the batch size
-        1. **Use Default Weights**: When enabled (default), training starts from pre-trained COCO weights. When disabled, starting weights are sourced from a prior training session you specify. See [Enable Training and Use Default Weights](../training/vision.md#enable-training-and-use-default-weights) for the full behaviour matrix.
+        1. **Use Default Weights**: When enabled (default), training starts from pre-trained COCO weights. When disabled, starting weights are sourced from a prior training session you specify.
+
+            !!! note "ModelPack does not have an Enable Training checkbox"
+                For ModelPack training always runs. Disabling **Use Default Weights** lets you supply a prior session's weights as the starting point; leaving it enabled trains from COCO pre-trained weights. **Enable Training** are [Ultralytics-only](../ultralytics/index.md#training-parameters) and do not apply here
     8. **Data Augmentation**: This section controls the probability of each augmentation technique.  This feature is crucial for training models and reduce overfitting, especially in small datasets
     9. **Export Parameters**: Allow the user to set a portion of data for calibration when exporting the model for INT8 quantization
     10. **Start Session**: This button will start the training session

--- a/docs/models/modelpack/index.md
+++ b/docs/models/modelpack/index.md
@@ -82,6 +82,7 @@ ModelPack can be trained now in EdgeFirst Studio using a Graphical User Interfac
         7. **Space to Depth**: This feature enables the Space to Depth Transformation to the input in order to reduce model complexity on higher resolutions
         8. **Split Decoder**: Remove the decoder from the model and use a very optimized one from EdgeFirst.  This feature is very useful when the location of the boxes has to be precise (0-offset)
     7. **Training Parameters**: In this section the user is able to specify the number of epochs to train the model as well as the batch size.  Remember the larger the input resolution the smaller the batch size
+        1. **Use Default Weights**: When enabled (default), training starts from pre-trained COCO weights. When disabled, starting weights are sourced from a prior training session you specify. See [Enable Training and Use Default Weights](../training/vision.md#enable-training-and-use-default-weights) for the full behaviour matrix.
     8. **Data Augmentation**: This section controls the probability of each augmentation technique.  This feature is crucial for training models and reduce overfitting, especially in small datasets
     9. **Export Parameters**: Allow the user to set a portion of data for calibration when exporting the model for INT8 quantization
     10. **Start Session**: This button will start the training session

--- a/docs/models/training/vision.md
+++ b/docs/models/training/vision.md
@@ -61,9 +61,27 @@ For more information on available "Data Augmentations" please see [Vision Augmen
     7. **Space to Depth**: This feature enables the Space to Depth Transformation to the input in order to reduce model complexity on higher resolutions
     8. **Split Decoder**: Remove the decoder from the model and use a very optimized one from EdgeFirst.  This feature is very useful when the location of the boxes has to be precise (0-offset)
 7. **Training Parameters**: In this section the user is able to specify the number of epochs to train the model as well as the batch size.  Remember the larger the input resolution the smaller the batch size
+    1. **Enable Training** *(Ultralytics only)*: When enabled (default), the model is trained using the selected weights. When disabled, no training is performed — weights are pushed directly to the session artifacts. See [Enable Training and Use Default Weights](#enable-training-and-use-default-weights) below.
+    2. **Use Default Weights**: When enabled (default), training starts from pre-trained COCO weights. When disabled, starting weights are sourced from a prior training session you specify.
 8. **Data Augmentation**: This section controls the probability of each augmentation technique.  This feature is crucial for training models and reduce overfitting, especially in small datasets
 9. **Export Parameters**: Allow the user to set a portion of data for calibration when exporting the model for INT8 quantization
 10. **Start Session**: This button will start the training session
+
+### Enable Training and Use Default Weights
+
+The **Enable Training** checkbox (Ultralytics only) and **Use Default Weights** checkbox combine to control how the session is initialized and whether active training is performed:
+
+| Use Default Weights | Enable Training | Behaviour |
+|---------------------|-----------------|----------|
+| ✓ Enabled | ✓ Enabled | **Default.** Train from pre-trained COCO weights. |
+| ✗ Disabled | ✓ Enabled | Train starting from weights of a prior training session you specify. |
+| ✓ Enabled | ✗ Disabled | No training. Pre-trained COCO weights are copied directly to the session artifacts. Results will be poor on non-COCO datasets — Studio displays a warning. |
+| ✗ Disabled | ✗ Disabled | No training. Weights are copied from a specified prior training session — equivalent to cloning that session's artifacts. |
+
+!!! warning "COCO pre-trained weights and dataset compatibility"
+    The **Use Default Weights** option initializes from pre-trained COCO weights. These weights can technically be used as a starting point for any dataset, but **if your dataset labels have no overlap with COCO category names, validation accuracy will be very poor** — the model's class outputs will not correspond to your labels.
+
+    For best transfer-learning results, ensure your label names match the relevant COCO categories, or supply a prior EdgeFirst training session as the starting weights.
 
 ## Session Progress
 

--- a/docs/models/ultralytics/index.md
+++ b/docs/models/ultralytics/index.md
@@ -75,7 +75,9 @@ YOLOv5, YOLOv8, YOLO11, and YOLO26 can be trained in EdgeFirst Studio using a Gr
         1. **Model Task**: This can be either "Detection" or "Segmentation". Note for Ultralytics segmentation refers to instance segmentation
         2. **Model Version**: The Ultralytics version to train from the choices (v5, v8, v11, v26)
         3. **Model Size**: The size of the model from the choices (Nano, Small, Medium, Large, XLarge)
-    7. **Training Parameters**: In this section the user is able to specify the number of epochs to train the model as well as the batch size.  Remember the larger the input resolution the smaller the batch size 
+    7. **Training Parameters**: In this section the user is able to specify the number of epochs to train the model as well as the batch size.  Remember the larger the input resolution the smaller the batch size
+        1. **Enable Training**: When enabled (default), the model is trained using the selected weights. When disabled, no training is performed — weights are pushed directly to the session artifacts. See the [behaviour matrix](../training/vision.md#enable-training-and-use-default-weights) for all combinations.
+        2. **Use Default Weights**: When enabled (default), training starts from pre-trained COCO weights. When disabled, starting weights are sourced from a prior training session you specify.
     8. **Export Parameters**: Allow the user to set a portion of data for calibration when exporting the model for INT8 quantization. This section also allow the user to set the ONNX opset version
     9. **Export Pretrained Weights**: A checkbox to export the default pretrained weights from Ultralytics
     10. **Start Session**: This button will start the training session

--- a/docs/models/ultralytics/index.md
+++ b/docs/models/ultralytics/index.md
@@ -76,8 +76,8 @@ YOLOv5, YOLOv8, YOLO11, and YOLO26 can be trained in EdgeFirst Studio using a Gr
         2. **Model Version**: The Ultralytics version to train from the choices (v5, v8, v11, v26)
         3. **Model Size**: The size of the model from the choices (Nano, Small, Medium, Large, XLarge)
     7. **Training Parameters**: In this section the user is able to specify the number of epochs to train the model as well as the batch size.  Remember the larger the input resolution the smaller the batch size
-        1. **Enable Training**: When enabled (default), the model is trained using the selected weights. When disabled, no training is performed — weights are pushed directly to the session artifacts. See the [behaviour matrix](../training/vision.md#enable-training-and-use-default-weights) for all combinations.
-        2. **Use Default Weights**: When enabled (default), training starts from pre-trained COCO weights. When disabled, starting weights are sourced from a prior training session you specify.
+        1. **Enable Training**: When enabled (default), the model is trained using the selected weights. When disabled, no training is performed — weights are pushed directly to the session artifacts. See the [behaviour matrix](../training/vision.md#enable-training-and-use-default-weights) for all combinations
+        2. **Use Default Weights**: When enabled (default), training starts from pre-trained COCO weights. When disabled, starting weights are sourced from a prior training session you specify
     8. **Export Parameters**: Allow the user to set a portion of data for calibration when exporting the model for INT8 quantization. This section also allow the user to set the ONNX opset version
     9. **Export Pretrained Weights**: A checkbox to export the default pretrained weights from Ultralytics
     10. **Start Session**: This button will start the training session

--- a/docs/models/validation/vision/user_managed.md
+++ b/docs/models/validation/vision/user_managed.md
@@ -11,14 +11,14 @@ For an alternative cloud-only flow, see [On Cloud Validation](managed.md). The m
 Both paths produce the same Studio validation session and the same set of accuracy charts. The difference is **where the validation session is created**:
 
 | If you... | Read |
-|---|---|
+| --------- | ---- |
 | Want to create the session in the Studio web UI, then run the profiler on the device | [Validation from Studio](../../../profiler/studio/from_studio.md) |
 | Want to browse training sessions inside the profiler TUI and create the session in place | [Validation from the Profiler](../../../profiler/studio/from_profiler.md) |
 
 ## Installation and connection
 
 | Topic | Read |
-|---|---|
+| ----- | ---- |
 | Install the profiler on the target board | [Installation guides](../../../profiler/installation/index.md) (per target) |
 | Sign in to EdgeFirst Studio | [Connecting to EdgeFirst Studio](../../../profiler/studio/connecting.md) |
 | Five-minute first profiling run | [Quick Start](../../../profiler/quickstart.md) |

--- a/docs/profiler/concepts/pipelining.md
+++ b/docs/profiler/concepts/pipelining.md
@@ -9,7 +9,7 @@ This page explains the conceptual model, the `--pipeline-depth` flag that contro
 Every frame travels through the same sequence of stages, in order:
 
 | Stage | Hardware | What it does |
-|---|---|---|
+| ----- | -------- | ------------ |
 | **decode** | CPU (libjpeg / hardware codec) | Read the encoded image file, decode to pixels |
 | **preprocess** | CPU + DMA | Resize, color-convert, quantize into the input tensor |
 | **inference** | NPU / GPU / CPU | Run the model |
@@ -47,7 +47,7 @@ Default depth is 2. Higher depths give more overlap headroom (useful when stage 
 Each inference backend has a maximum pipeline depth determined by how many concurrent inference clients the hardware can serve. The profiler clamps `--pipeline-depth` to that maximum at startup:
 
 | Backend | Default max depth |
-|---|---:|
+| ------- | ----------------: |
 | ONNX Runtime (CPU / CUDA / CoreML) | 2 |
 | TFLite XNNPACK | 2 |
 | TFLite Neutron (i.MX 95) | 2 |

--- a/docs/profiler/installation/imx8mplus.md
+++ b/docs/profiler/installation/imx8mplus.md
@@ -35,7 +35,7 @@ edgefirst-profiler --version
 ## Delegate selection
 
 | Value | Behavior on i.MX 8M Plus |
-|---|---|
+| ----- | ------------------------ |
 | _(omitted)_ / `auto` | Auto-detects i.MX 8M Plus from device-tree compatible string and loads `libvx_delegate.so`. |
 | `xnnpack` | CPU baseline. |
 | `none` / `cpu` | Reference kernels only. |

--- a/docs/profiler/installation/imx95.md
+++ b/docs/profiler/installation/imx95.md
@@ -38,7 +38,7 @@ edgefirst-profiler --version
 The profiler picks a TFLite delegate automatically — and you can override it on the validation session if needed. Delegate values:
 
 | Value | Behavior |
-|---|---|
+| ----- | -------- |
 | _(omitted)_ / `auto` | Probe well-known NPU paths (`/usr/lib/libneutron_delegate.so`, `/usr/lib/libvx_delegate.so`); fall back to XNNPACK. |
 | `xnnpack` | Explicit XNNPACK CPU delegate. |
 | `none` / `cpu` | No delegate — reference kernels. |

--- a/docs/profiler/installation/index.md
+++ b/docs/profiler/installation/index.md
@@ -11,7 +11,7 @@ Per-target pages below cover the runtime libraries, NPU delegates, daemons, and 
 ## Supported targets
 
 | Target | Architecture | Default backend | Optional accelerator |
-|---|---|---|---|
+| ------ | ------------ | --------------- | -------------------- |
 | [Linux](linux.md) | x86_64, aarch64 | ONNX Runtime (CPU) | TFLite XNNPACK |
 | [macOS](macos.md) | Apple Silicon | ONNX Runtime (CPU) | CoreML execution provider |
 | [Windows](windows.md) | x86_64 | ONNX Runtime (CPU) | — |
@@ -29,7 +29,7 @@ The profiler CLI and the workflow it drives are the same on every target — wha
 The inference backend is chosen automatically from the model file extension:
 
 | Extension | Backend | Runtime dependency |
-|---|---|---|
+| --------- | ------- | ------------------ |
 | `.onnx` | ONNX Runtime | `libonnxruntime.so` (Linux) / `libonnxruntime.dylib` (macOS) / `onnxruntime.dll` (Windows) |
 | `.tflite` | TensorFlow Lite | `libtensorflowlite_c.so` (Linux only) |
 | `.dvm` | Kinara Ara-2 | `ara2-proxy` daemon (Linux only) |

--- a/docs/profiler/installation/macos.md
+++ b/docs/profiler/installation/macos.md
@@ -58,7 +58,7 @@ Then run a validation session — see [Validation from Studio](../studio/from_st
 ## What is not supported on macOS
 
 | Backend | Why not |
-|---|---|
+| ------- | ------- |
 | TensorFlow Lite | `libtensorflowlite_c.so` is Linux-only in the EdgeFirst distribution |
 | NXP Neutron / VSI delegates | Delegates ship with NXP Linux BSPs only |
 | Kinara Ara-2 | `ara2-proxy` daemon is Linux-only |

--- a/docs/profiler/studio/connecting.md
+++ b/docs/profiler/studio/connecting.md
@@ -11,7 +11,7 @@ edgefirst-profiler login
 The login command prompts for **server**, **username**, and **password** in turn. Server values:
 
 | Value | URL |
-|---|---|
+| ----- | --- |
 | `saas` _(default)_ | `https://edgefirst.studio` |
 | `stage` | `https://stage.edgefirst.studio` |
 | `test` | `https://test.edgefirst.studio` |

--- a/docs/profiler/studio/from_profiler.md
+++ b/docs/profiler/studio/from_profiler.md
@@ -39,7 +39,7 @@ Each level renders the same metadata you see in the Studio web UI: project owner
 When you select an artifact (e.g., `best.onnx`, `best.tflite`, `best.engine`), an action menu pops up:
 
 | Action | Behavior |
-|---|---|
+| ------ | -------- |
 | **Validate** | Create a new validation session bound to this artifact and the training session's dataset, then jump to the F4 Profiler screen to run it. |
 | **Live** | _(reserved)_ Stream live inference back to Studio rather than producing a validation session — covered in a future release. |
 

--- a/docs/studio/apps.md
+++ b/docs/studio/apps.md
@@ -30,7 +30,7 @@ app run is tracked in the [Tasks panel](navigation.md#tasks).
 The following apps are available by default in EdgeFirst Studio:
 
 | App | Description | Pricing |
-|---|---|---|
+| --- | ----------- | ------- |
 | **Roboflow Importer** | Import datasets from Roboflow into EdgeFirst Studio. | Free |
 | **EdgeFirst Profiler** | Profile model inference pipelines and produce timing traces. | Free |
 | **EdgeFirst Validator** | Post-process predictions and timing traces to compute COCO/LVIS accuracy metrics and timing charts, then publish results to the validation session. | Free |

--- a/docs/studio/datasets/history.md
+++ b/docs/studio/datasets/history.md
@@ -16,7 +16,7 @@ for the dataset.  Versions allow you to pin a known-good state of a dataset so i
 can be referenced by training or validation sessions and restored at any time.
 
 | Column | Description |
-|---|---|
+| ------ | ----------- |
 | **Serial** | Sequential version index starting at 0. |
 | **Date** | When the version was tagged. |
 | **User** | The user who created the tag. |
@@ -45,7 +45,7 @@ regardless of whether it was tagged as a version.  This provides a fine-grained 
 trail of who changed what and when.
 
 | Column | Description |
-|---|---|
+| ------ | ----------- |
 | **Serial** | Sequential event index. |
 | **Date** | When the change occurred. |
 | **User** | The user who made the change. |

--- a/docs/studio/datasets/map.md
+++ b/docs/studio/datasets/map.md
@@ -13,7 +13,7 @@ navigation after opening the datasets list.
 ## Map Controls
 
 | Control | Description |
-|---|---|
+| ------- | ----------- |
 | **+** / **–** buttons | Zoom in and out on the map. |
 | **Filter** | Open the filter panel to narrow which datasets are shown on the map. |
 | **Source Dataset** selector | Choose which specific dataset's GPS points are displayed on the map. |

--- a/docs/studio/models.md
+++ b/docs/studio/models.md
@@ -52,13 +52,12 @@ The action bar at the top of the details page provides the following operations:
 - **Refresh** — Reload the session state and latest log output.
 - **Validate** — Create a new validation session for this training session.
 - **Compare** — Compare the training charts of this session against others.
-- **Clone** — Copy this session's settings and weights into a new training session without running training. See [Cloning a Training Session](#cloning-a-training-session).
 - **Stop** — Terminate a running training session.
 - **Recycle Bin** — Move the session to the recycle bin.
 
 ### Cloning a Training Session
 
-Cloning creates a new training session that is an exact copy of an existing one — same trainer type, same model and training parameters — but **no training is performed**. The completed weights from the source session are copied directly to the new session's artifacts.
+Cloning creates a new training session from an existing one. The clone preserves the source session's trainer type, model, dataset selection, and other session configuration, but it overrides two training controls: **Use Default Weights** is disabled and **Enable Training** is disabled. Because training is not run, the completed weights from the source session are copied directly into the new session's artifacts.
 
 This is useful when you want to:
 

--- a/docs/studio/models.md
+++ b/docs/studio/models.md
@@ -40,7 +40,7 @@ a deep view into the session through the following tabs:
 {{ figure("assets/models/training-session-details.png", "Training Session Details") }}
 
 | Tab | Description |
-|---|---|
+| --- | ----------- |
 | **Session** | Summary of the session configuration: session ID, name, description, created by, status, dataset, annotation set, train/val groups, start date, and duration.  Also shows the training parameters in YAML format and the status of each trainer process stage. |
 | **Logs** | Live and historical console output from the training process. |
 | **Charts** | Training metrics plotted over epochs, such as loss curves and mAP. |
@@ -52,8 +52,24 @@ The action bar at the top of the details page provides the following operations:
 - **Refresh** — Reload the session state and latest log output.
 - **Validate** — Create a new validation session for this training session.
 - **Compare** — Compare the training charts of this session against others.
+- **Clone** — Copy this session's settings and weights into a new training session without running training. See [Cloning a Training Session](#cloning-a-training-session).
 - **Stop** — Terminate a running training session.
 - **Recycle Bin** — Move the session to the recycle bin.
+
+### Cloning a Training Session
+
+Cloning creates a new training session that is an exact copy of an existing one — same trainer type, same model and training parameters — but **no training is performed**. The completed weights from the source session are copied directly to the new session's artifacts.
+
+This is useful when you want to:
+
+- Reuse a trained model as a starting point for fine-tuning with a different dataset.
+- Preserve a snapshot of a model at a specific training state before further experimentation.
+- Share a model artifact under a new session name without re-running training.
+
+To clone a session, click "clone training session" button on the training card.  A dialog will appear pre-filled with the source session's configuration.  Adjust the name and description as needed, then confirm.
+
+!!! note
+    Cloning is equivalent to creating a new session with **Use Default Weights** disabled and **Enable Training** disabled.  See [Enable Training and Use Default Weights](../models/training/vision.md#enable-training-and-use-default-weights) for the full behaviour matrix.
 
 ## Validation Sessions
 
@@ -89,7 +105,7 @@ provides the following tabs:
 {{ figure("assets/models/validation-session-details.png", "Validation Session Details") }}
 
 | Tab | Description |
-|---|---|
+| --- | ----------- |
 | **Session** | Summary of the session: session ID, status, name, model used, linked training session, dataset, start date, and duration.  Also shows the validation parameters in YAML format. |
 | **Logs** | Console output from the validation run. |
 | **Charts** | Validation metric charts such as precision-recall curves. |

--- a/docs/studio/recycle.md
+++ b/docs/studio/recycle.md
@@ -32,7 +32,7 @@ Click **Clear All** to deselect all types, then check only the types you want to
 Filter by when the item was deleted:
 
 | Option | Description |
-|---|---|
+| ------ | ----------- |
 | Today | Items deleted today. |
 | 7 Days | Items deleted in the last 7 days. |
 | 30 Days | Items deleted in the last 30 days. |
@@ -45,7 +45,7 @@ Filter by when the item was deleted:
 The main table lists all items matching the active filters.  The table shows:
 
 | Column | Description |
-|---|---|
+| ------ | ----------- |
 | **Description** | The name of the deleted item.  Click the name to view its details. |
 | **Project** | The project the item belonged to, if applicable. |
 | **Date Removed** | When the item was moved to the recycle bin. |

--- a/docs/studio/tasks.md
+++ b/docs/studio/tasks.md
@@ -43,7 +43,7 @@ heading reflects the total number of historical tasks matching the current filte
 Each task card shows the following information:
 
 | Field | Description |
-|---|---|
+| ----- | ----------- |
 | **Task ID** | A unique identifier for the task (e.g. `bt-445d`). Click the copy icon to copy it to the clipboard. |
 | **Status** | The current state of the task: **Completed**, **Running**, **Failed**, or **Stopped**. |
 | **Name** | The display name assigned to the task at creation time. |

--- a/docs/studio/user/subscription.md
+++ b/docs/studio/user/subscription.md
@@ -30,7 +30,7 @@ and annual billing.  Annual billing reduces the effective monthly cost.
 EdgeFirst Studio offers the following subscription tiers:
 
 | Feature | Free (Public) | Professional ($179/month) | Teams ($359/month) |
-|---|---|---|---|
+| ------- | ------------- | ------------------------- | ------------------ |
 | Active Users | 1 | 1 | 20 |
 | Image Storage | 100K | 500K | 4M |
 | Projects | 3 | 10 | 30 |


### PR DESCRIPTION
- Add Enable Training (Ultralytics) and Use Default Weights (all trainers) documentation with 2×2 behaviour matrix and COCO weight compatibility warning ([DE-2623](https://au-zone.atlassian.net/browse/DE-2623), [DE-2624](https://au-zone.atlassian.net/browse/DE-2624))
- Add Use Default Weights sub-item to ModelPack and Ultralytics training parameter references
- Add Clone Training Session section to Studio Models dashboard docs
- Fix table separator formatting across 18 docs files — expand minimal |---| separators to match header column widths and normalise cell spacing

[DE-2623]: https://au-zone.atlassian.net/browse/DE-2623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DE-2624]: https://au-zone.atlassian.net/browse/DE-2624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ