### PR TITLE
DE-2667: Add Model Zoo admonition to all converter pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.
 
 ### Added
 
+- Model Zoo callout admonition added to all five converter pages
+  (`tflite`, `neutron`, `tensorrt`, `ara2`, `hailo`) directing users to the
+  [EdgeFirst Model Zoo on Hugging Face](https://huggingface.co/spaces/EdgeFirst/Models)
+  for the latest supported model list, platform-specific validation results, and
+  benchmark numbers.
+
 - `mkdocs-redirects` plugin with a `redirect_maps` configuration so previously
   published documentation URLs no longer return 404 after pages were moved or
   renamed. The redirect map covers the model conversion documentation that was

--- a/docs/models/conversion/ara2.md
+++ b/docs/models/conversion/ara2.md
@@ -4,6 +4,9 @@ The **Ara2 Converter** compiles an ONNX model exported from an EdgeFirst Studio 
 
 The Ara2 Converter applies [Smart Quantization](/models/conversion/#smart-quantization) the same way the other INT8 converters do — by cutting the graph upstream of the decode where the trainer's `split_hints` allow it. What is unique to Ara2 is an additional accuracy lever: the Ara240 DNPU has DRAM and tolerates large output tensors, so the converter can also **promote the most quantization-hostile arithmetic inside the detect head from INT8 to INT16** while leaving it inside the quantized graph. INT16 has roughly 256× the headroom of INT8 and is enough to make the distance-to-box decoding stable without lifting it onto the CPU.
 
+!!! tip "Model Zoo — Supported Models & Benchmarks"
+    For the latest supported model list, INT8/INT16 accuracy comparisons, and validation results on the NXP Ara240 DNPU, see the [EdgeFirst Model Zoo](https://huggingface.co/spaces/EdgeFirst/Models) on Hugging Face.
+
 ## Studio Launch Form
 
 | Field | Values | Default | Meaning |

--- a/docs/models/conversion/hailo.md
+++ b/docs/models/conversion/hailo.md
@@ -7,6 +7,9 @@ The **Hailo Converter** compiles an ONNX model exported from an EdgeFirst Studio
 
 The Hailo Converter applies [Smart Quantization](/models/conversion/#smart-quantization) by automatic per-scale graph surgery. On Hailo this is **not optional** — the per-context SRAM budget on Hailo silicon cannot hold a typical detection head's full concatenated output tensor in a single pass, and the Hailo Dataflow Compiler will reject the model outright. Cutting the graph at per-scale endpoints makes each tensor small enough to fit, *and* gives each one its own independently calibrated INT8 (or INT16) scale as a structural by-product.
 
+!!! tip "Model Zoo — Supported Models & Benchmarks"
+    For the latest supported model list, per-preset accuracy benchmarks, and validation results on Hailo-8 and Hailo-8L, see the [EdgeFirst Model Zoo](https://huggingface.co/spaces/EdgeFirst/Models) on Hugging Face.
+
 ## Studio Launch Form
 
 | Field | Values | Default | Meaning |

--- a/docs/models/conversion/neutron.md
+++ b/docs/models/conversion/neutron.md
@@ -4,6 +4,9 @@ The **Neutron Converter** re-encodes a quantized TFLite model for execution on *
 
 Neutron Converter is a **re-encoder, not a quantizer** — all quantization decisions are made upstream by the [TFLite Converter](/models/conversion/tflite/). If the matching quantized TFLite artifact does not already exist when the Neutron Converter launches, Studio triggers the TFLite Converter automatically and waits for it to complete. From the user's perspective the conversion is a single click; behind the scenes it is a two-stage pipeline that produces both a deployable TFLite artifact and a Neutron-compiled artifact for the chosen target.
 
+!!! tip "Model Zoo — Supported Models & Benchmarks"
+    For the latest supported model list, per-model validation results, and benchmark numbers across the eIQ Neutron silicon family (i.MX 95, i.MX 94x, and more), see the [EdgeFirst Model Zoo](https://huggingface.co/spaces/EdgeFirst/Models) on Hugging Face.
+
 ## Studio Launch Form
 
 The launch form has two field groups: an **upstream** group plumbed through to the TFLite Converter, and a **conversion** group that controls the Neutron stage itself.

--- a/docs/models/conversion/tensorrt.md
+++ b/docs/models/conversion/tensorrt.md
@@ -4,6 +4,9 @@ The **TensorRT Converter** prepares an ONNX model exported from an EdgeFirst Stu
 
 This design is forced by TensorRT's binary contract: TensorRT 10.3 engine binaries are platform-locked at the OS and ABI level. An engine built on AWS Batch (x86-64) is rejected by the Jetson aarch64 TRT runtime with a "platform tag mismatch" error, even when the GPU compute capabilities match. NVIDIA's own DeepStream / TAO workflow defers the engine build to the target device for the same reason; the TensorRT Converter follows that pattern.
 
+!!! tip "Model Zoo — Supported Models & Benchmarks"
+    For the latest supported model list, FP16 accuracy benchmarks, and validation results on NVIDIA Jetson, see the [EdgeFirst Model Zoo](https://huggingface.co/spaces/EdgeFirst/Models) on Hugging Face.
+
 ## Studio Launch Form
 
 The TensorRT Converter exposes **no conversion knobs** in EdgeFirst Studio — there is no `conversion` group on the launch form. You pick the training session and click **Start App**; the form includes an informational note explaining that the output is a portable bundle requiring an on-device build step.

--- a/docs/models/conversion/tflite.md
+++ b/docs/models/conversion/tflite.md
@@ -4,6 +4,9 @@ The **TFLite Converter** is the EdgeFirst reference quantizer. It takes a Tensor
 
 INT8 is the recommended deployment precision; float16 and float32 paths exist for cases where INT8 accuracy is not yet acceptable. INT8 conversion applies the [EdgeFirst Smart Quantizer](/models/conversion/#smart-quantization) — per-scale graph surgery that gives each feature-pyramid endpoint its own independent quantization parameters and lifts the decode operations out of the INT8 datapath onto the runtime side. Calibration is fully automatic from the training session.
 
+!!! tip "Model Zoo — Supported Models & Benchmarks"
+    For the latest supported model list, per-model validation results, and INT8 accuracy benchmarks on i.MX 8M Plus and other TFLite targets, see the [EdgeFirst Model Zoo](https://huggingface.co/spaces/EdgeFirst/Models) on Hugging Face.
+
 ## Studio Launch Form
 
 | Field | Values | Default | Meaning |


### PR DESCRIPTION
Add a tip admonition to each of the five converter pages (TFLite, Neutron, TensorRT, Ara2, Hailo) pointing users to the EdgeFirst Model Zoo on Hugging Face for the latest supported model list, platform validation results, and benchmark numbers. Each admonition is tailored to its converter's target platform.