### PR TITLE
Bugfix/deploy timeout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,6 @@
-docs/platforms/quickstart/jetson_orin/assets/torchvision-0.18.0a0+6043bc2-cp310-cp310-linux_aarch64.whl filter=lfs diff=lfs merge=lfs -text
-docs/platforms/quickstart/jetson_orin/assets/yolov8s-seg-fp16.engine filter=lfs diff=lfs merge=lfs -text
 docs/models/deployment/assets/coffeecup-modelpack-multitask-t-1f54.onnx filter=lfs diff=lfs merge=lfs -text
 docs/models/deployment/assets/coffeecup-modelpack-multitask-t-1f54.tflite filter=lfs diff=lfs merge=lfs -text
 docs/models/deployment/assets/coffeecup-yolov8n-segmentation-rgb-640x640-t-266e.onnx filter=lfs diff=lfs merge=lfs -text
 docs/models/deployment/assets/coffeecup-yolov8n-segmentation-rgb-640x640-t-266e_quant-u8-i8.tflite filter=lfs diff=lfs merge=lfs -text
-docs/models/ultralytics/assets/yolov8s-seg_full_integer_quant.tflite filter=lfs diff=lfs merge=lfs -text
-docs/models/ultralytics/assets/yolov8s-seg_full_integer_quant_converted.tflite filter=lfs diff=lfs merge=lfs -text
-docs/models/modelpack/assets/coffeecup-modelpack-multitask-t-1f54.onnx filter=lfs diff=lfs merge=lfs -text
-docs/models/modelpack/assets/coffeecup-modelpack-multitask-t-1f54.tflite filter=lfs diff=lfs merge=lfs -text
 *.gif filter=lfs diff=lfs merge=lfs -text
+*.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ permissions:
 
 concurrency:
   group: github-pages
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ permissions:
 
 concurrency:
   group: github-pages
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.
   table, Profiler feature ribbon, free credits tip, and "Is EdgeFirst Studio right
   for you?" section linking to the Tourist workflow.
 - **Tourist workflow** (`discrete/workflows/tourist.md`): new "Is EdgeFirst Studio
-  for you?" section with four clickable GIFs (auto-labelling, model-optimization,
-  3D perception, profiler) linking to their respective documentation sections.
+  for you?" section with four autoplaying looping videos (auto-labelling,
+  model-optimization, 3D perception, profiler).
 - **Free credits note** added to `index.md`, `getting_started/workflows/index.md`,
   and `studio/user/index.md` (\$50 sign-up credit + \$15/month recurring).
 - **Profiler feature ribbon** (`ef-feature-ribbon` CSS component) added to
@@ -29,7 +29,11 @@ file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.
   instead of the cloud validation path.
 - **Login page** (`getting_started/login.md`): rewrote the transition sentence to
   be more inviting; added PC/phone/camera context and a "Next →" footer link.
-- Four workflow GIF assets added under `getting_started/assets/workflows/`.
+- Four workflow video assets (MP4) added under `getting_started/assets/workflows/`.
+- **`video()` mkdocs-macro** (`macros.py`): renders an autoplaying, looping, muted
+  inline `<video>` that behaves like a GIF; resolves the `<source>` URL via
+  `get_relative_url` so it works under `use_directory_urls` and the versioned
+  (mike) deployment, where MkDocs does not rewrite raw `<source>` URLs.
 - **2D annotation guide** (`discrete/datasets/annotate_2d_dataset.md`): enhanced
   with AGTG server launch steps, timeout warning, video playback verification tip,
   and back-to-gallery navigation. New screenshot assets added.
@@ -37,8 +41,8 @@ file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.
   public datasets description and new "Browse Public Experiments" section.
 - **Mobile image import screenshot** (`docs/datasets/assets/capture/mobile-image-import-fields.jpg`):
   new asset for uploading images workflow documentation.
-- **AGTG tutorial GIF** (`getting_started/assets/workflows/AGTG-tutorial.gif`):
-  new animated asset demonstrating annotation workflow.
+- **AGTG tutorial video** (`getting_started/assets/workflows/AGTG-tutorial.mp4`):
+  new asset demonstrating the annotation workflow.
 - **Device compatibility note** added to `recording_on_phone.md` explaining that
   screenshots are Samsung-based and device UIs may vary across manufacturers.
 - **Tutorials & Guides hub** (`docs/index.md`): Material grid-cards section linking
@@ -88,8 +92,17 @@ file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.
   screenshots for improved user clarity and step-by-step guidance.
 - **Workflow documentation clarified** in `discrete/datasets/uploading_*.md` and
   workflow files for improved user guidance.
-- **GIF files tracked with Git LFS** (`.gitattributes` updated) to manage large
-  animated assets efficiently and avoid GitHub file size warnings.
+- **Workflow GIFs converted to MP4**: six animated GIFs (auto-labelling,
+  model-optimization, 3D perception, profiler, AGTG-tutorial, and
+  `perception/dev/examples` boxes2d tracking) re-encoded as H.264 MP4 via the new
+  `video()` macro, shrinking the documentation media payload from ~156 MB to
+  ~8.8 MB to keep the GitHub Pages deploy within its size/time limits.
+- **`*.mp4` and `*.gif` tracked with Git LFS** (`.gitattributes`) to manage large
+  media assets efficiently and avoid GitHub file size warnings; stale
+  individual model-file LFS rules removed.
+- **Unused model assets removed**: duplicate
+  `models/modelpack/assets/coffeecup-modelpack-multitask-t-1f54.{onnx,tflite}` and
+  unreferenced `models/ultralytics/assets/yolov8s-seg_full_integer_quant*.tflite`.
 - `models/assets/deployment/run-model-button.jpg` removed (unused asset).
 - `getting_started/assets/workflows/dataset-groups.jpg` removed (outdated asset).
 - `getting_started/workflows/index.md` free credits note dollar signs escaped to

--- a/docs/datasets/tutorials/annotations/automatic.md
+++ b/docs/datasets/tutorials/annotations/automatic.md
@@ -101,7 +101,7 @@ Please wait while the server is being initialized.
 
 ### Annotate Starting Frame
 
-{{ figure("../../../getting_started/assets/workflows/AGTG-tutorial.gif", "AGTG Preview") }}
+{{ video("../../../getting_started/assets/workflows/AGTG-tutorial.mp4", "AGTG Preview") }}
 
 Once the server has been initialized, annotate the starting frame.  This is the only annotation required by the user. The rest of the frames will be annotated by SAM-2 and the AGTG process.  This step is also known as initializing the SAM-2 state.  Each object must be annotated independently so the tracker can assign a unique ID.
 

--- a/docs/discrete/datasets/annotate_2d_dataset.md
+++ b/docs/discrete/datasets/annotate_2d_dataset.md
@@ -38,7 +38,7 @@ Go ahead and launch the AGTG server.  Please allow ~5mins for the server to init
 
 Once the AGTG server has started, go ahead and [annotate the starting frame](../../datasets/tutorials/annotations/automatic.md#annotate-starting-frame).  Once the starting frame has been annotated, go ahead and [propagate the annotations](../../datasets/tutorials/annotations/automatic.md#propagate) throughout the rest of the frames.
 
-{{ figure("/getting_started/assets/workflows/AGTG-tutorial.gif", "AGTG Preview") }}
+{{ video("/getting_started/assets/workflows/AGTG-tutorial.mp4", "AGTG Preview") }}
 
 {{ figure("/datasets/assets/annotations/automatic/agtg-prompts.jpg", "AGTG Initial Prompts") }}
 

--- a/docs/discrete/workflows/tourist.md
+++ b/docs/discrete/workflows/tourist.md
@@ -2,10 +2,10 @@
 
 <div class="grid" markdown="1">
 
-{{ figure("/getting_started/assets/workflows/auto-labelling.gif", "Auto-Labelling — AI-generated bounding boxes and segmentation masks") }}
-{{ figure("/getting_started/assets/workflows/model-optimization.gif", "Model Optimization — train, compare, and benchmark vision models") }}
-{{ figure("/getting_started/assets/workflows/3d_perception.gif", "3D Perception — LiDAR, RADAR, and depth sensor workflows") }}
-{{ figure("/getting_started/assets/workflows/profiler.gif", "EdgeFirst Profiler — on-target benchmarking with latency and accuracy metrics") }}
+{{ video("/getting_started/assets/workflows/auto-labelling.mp4", "Auto-Labelling — AI-generated bounding boxes and segmentation masks") }}
+{{ video("/getting_started/assets/workflows/model-optimization.mp4", "Model Optimization — train, compare, and benchmark vision models") }}
+{{ video("/getting_started/assets/workflows/3d_perception.mp4", "3D Perception — LiDAR, RADAR, and depth sensor workflows") }}
+{{ video("/getting_started/assets/workflows/profiler.mp4", "EdgeFirst Profiler — on-target benchmarking with latency and accuracy metrics") }}
 
 </div>
 

--- a/docs/getting_started/assets/workflows/3d_perception.gif
+++ b/docs/getting_started/assets/workflows/3d_perception.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b3fcfd846414c1ed63fce39638da1d7625f844c25125723473671f66aa0bd9a4
-size 7716087

--- a/docs/getting_started/assets/workflows/3d_perception.mp4
+++ b/docs/getting_started/assets/workflows/3d_perception.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5f556d55399852bb4f6d782b954f87ca7e9a24c1702ecc50992836f3920d18c
+size 1033083

--- a/docs/getting_started/assets/workflows/AGTG-tutorial.gif
+++ b/docs/getting_started/assets/workflows/AGTG-tutorial.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:61047fd708affa5032cecfa97c7558b3cf93a548abbe5b196c75dfb160139583
-size 97648891

--- a/docs/getting_started/assets/workflows/AGTG-tutorial.mp4
+++ b/docs/getting_started/assets/workflows/AGTG-tutorial.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:334b799112b5333c043e736e7aeaa0575a8a21bd5a77ea5d617316a16c6766d1
+size 1309388

--- a/docs/getting_started/assets/workflows/auto-labelling.gif
+++ b/docs/getting_started/assets/workflows/auto-labelling.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:00689758b530d48ca0cff7efed0175bd4e4dad24e9762d9bc1a8cc0c64896dbc
-size 7010936

--- a/docs/getting_started/assets/workflows/auto-labelling.mp4
+++ b/docs/getting_started/assets/workflows/auto-labelling.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff28f8ae0ec631ff01d039d888e00cc9d47b206da5e67e8a999ad5bc1ceb288c
+size 3594256

--- a/docs/getting_started/assets/workflows/model-optimization.gif
+++ b/docs/getting_started/assets/workflows/model-optimization.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa0d9ff049cd5e065abe49e2cf8776815e3ff6b69a37397bc33eb0343be25d38
-size 14252794

--- a/docs/getting_started/assets/workflows/model-optimization.mp4
+++ b/docs/getting_started/assets/workflows/model-optimization.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18ca777150b8b79cd49e2a0274eb89ad25c138f35f1bd6f106b81b72771ba346
+size 1684669

--- a/docs/getting_started/assets/workflows/profiler.gif
+++ b/docs/getting_started/assets/workflows/profiler.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:25e0235ffac4cdc1f21eaabec69a83a16971ebe247c472d58d6bd92772b1b4da
-size 26415094

--- a/docs/getting_started/assets/workflows/profiler.mp4
+++ b/docs/getting_started/assets/workflows/profiler.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d8887b0fde5b1bb3076dc6ef7f7a4498cadeb6ab84e0c911b684cc39b716243
+size 1453306

--- a/docs/models/modelpack/assets/coffeecup-modelpack-multitask-t-1f54.onnx
+++ b/docs/models/modelpack/assets/coffeecup-modelpack-multitask-t-1f54.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f52b7d390d77729225a76affae68addfab87785454cd930dc908438f9c7b61f
-size 31282674

--- a/docs/models/modelpack/assets/coffeecup-modelpack-multitask-t-1f54.tflite
+++ b/docs/models/modelpack/assets/coffeecup-modelpack-multitask-t-1f54.tflite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d54d5b248184019212e17dda20b520ff813cbec8f60d8e4052af67cfd09e52bc
-size 7955416

--- a/docs/models/ultralytics/assets/yolov8s-seg_full_integer_quant.tflite
+++ b/docs/models/ultralytics/assets/yolov8s-seg_full_integer_quant.tflite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:703f6d2f6d3732b11b998768b7015f549ff91a33fa4bb6ac77187e0c4ad7b8ad
-size 11978001

--- a/docs/models/ultralytics/assets/yolov8s-seg_full_integer_quant_converted.tflite
+++ b/docs/models/ultralytics/assets/yolov8s-seg_full_integer_quant_converted.tflite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:970ded11fe19d05e946cdd2b08ff58831be59f5600ae6abd4f90f3c9e640708c
-size 12400112

--- a/docs/perception/dev/examples/assets/boxes2d_tracking.gif
+++ b/docs/perception/dev/examples/assets/boxes2d_tracking.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c58ca6b67c7d17702314ff873e38a6d8442edad37530a6933fbcb223f69ac467
-size 10781984

--- a/docs/perception/dev/examples/assets/boxes2d_tracking.mp4
+++ b/docs/perception/dev/examples/assets/boxes2d_tracking.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdbd0541c764ae16a673cee07e6de9ca9d9e04c2dc63d1be3224e1502c23a8d9
+size 123047

--- a/docs/perception/dev/examples/model.md
+++ b/docs/perception/dev/examples/model.md
@@ -260,7 +260,7 @@ On your EdgeFirst Platform you can also allow tracking of the boxes and this can
 
 The main adjustments are that a color will be specified and each tracked box will have its own color as well as that we will add in the unique ID for the box into the label. All of this is contingent on tracking being enabled. The following image is taken when applied to a combined example.
 
-![Boxes2D Tracking](assets/boxes2d_tracking.gif)
+{{ video("assets/boxes2d_tracking.mp4", "Boxes2D Tracking") }}
 
 ## Model Mask
 

--- a/macros.py
+++ b/macros.py
@@ -1,5 +1,6 @@
 # macros.py
 import os
+from html import escape
 
 from mkdocs.utils import get_relative_url
 
@@ -75,14 +76,20 @@ def define_env(env):
         page = env.page
         src = get_relative_url(doc_path_of(path, page), page.url)
 
-        style = f' style="width:{width}"' if width is not None else ""
+        style = ""
+        if width is not None:
+            css_width = str(width).strip()
+            if css_width and css_width.isdigit():
+                css_width = f"{css_width}px"
+            style = f' style="width:{escape(css_width, quote=True)}"'
+        alt_text = escape(alt)
         return (
             f'<figure markdown="span">\n'
             f'<video autoplay loop muted playsinline{style}>\n'
-            f'<source src="{src}" type="video/mp4">\n'
-            f'{alt}\n'
+            f'<source src="{escape(src, quote=True)}" type="video/mp4">\n'
+            f'{alt_text}\n'
             f'</video>\n'
-            f'<figcaption>{alt}</figcaption>\n'
+            f'<figcaption>{alt_text}</figcaption>\n'
             f'</figure>'
         )
 

--- a/macros.py
+++ b/macros.py
@@ -1,6 +1,8 @@
 # macros.py
 import os
 
+from mkdocs.utils import get_relative_url
+
 def define_env(env):
     show_paths = env.variables.get("show_image_paths", False)
     studio_urls = {
@@ -19,6 +21,19 @@ def define_env(env):
             full_path = os.path.relpath(docs_relative, page_dir)
             full_path = full_path.replace(os.sep, "/")
         return full_path
+    
+    def doc_path_of(path, page):
+        """Resolve an asset reference to its docs-root-relative path.
+
+        Accepts an absolute (``/foo/bar.mp4``) or page-relative
+        (``../foo/bar.mp4``) reference and returns the normalized path
+        relative to the docs root (e.g. ``foo/bar.mp4``).
+        """
+        if path.startswith("/"):
+            return path.lstrip("/")
+        page_dir = os.path.dirname(page.file.src_path)
+        resolved = os.path.normpath(os.path.join(page_dir, path))
+        return resolved.replace(os.sep, "/")
 
     def img(path, alt):
         page = env.page
@@ -46,7 +61,31 @@ def define_env(env):
             ![{alt}]({path}{tooltip}){{ align=center width={width} }}
             <figcaption>{alt}</figcaption>
             </figure>'''
-        
+
+    def video(path, alt, width=None):
+        """Return an autoplaying, looping, muted inline video that behaves
+        like a GIF.
+
+        The source is resolved relative to the rendered page URL (via
+        MkDocs' get_relative_url) so it works under use_directory_urls and
+        the versioned (mike) deployment. Unlike <img> tags, MkDocs does not
+        rewrite raw <source> URLs, so resolve_path (which is relative to the
+        source file directory) cannot be reused here.
+        """
+        page = env.page
+        src = get_relative_url(doc_path_of(path, page), page.url)
+
+        style = f' style="width:{width}"' if width is not None else ""
+        return (
+            f'<figure markdown="span">\n'
+            f'<video autoplay loop muted playsinline{style}>\n'
+            f'<source src="{src}" type="video/mp4">\n'
+            f'{alt}\n'
+            f'</video>\n'
+            f'<figcaption>{alt}</figcaption>\n'
+            f'</figure>'
+        )
+
     def studio_url(name="studio"):
         """Return a shared EdgeFirst Studio URL by key."""
         if name not in studio_urls.keys():
@@ -58,6 +97,7 @@ def define_env(env):
         return f'<a href="{studio_url(name)}">{text}</a>'
 
     env.macros.figure = figure
+    env.macros.video = video
     env.macros.img = img
     env.macros.studio_url = studio_url
     env.macros.studio_link = studio_link


### PR DESCRIPTION
Convert workflow GIFs to MP4 to fix Pages deploy timeout

Replace six large animated GIFs (~156 MB total) with H.264 MP4
equivalents (~8.8 MB) to shrink the GitHub Pages payload and avoid the
deployment timeout. Add a `video()` mkdocs-macro that renders an
autoplaying, looping, muted inline <video> so the MP4s behave like the
original GIFs; resolve the <source> URL via get_relative_url so it works
under use_directory_urls and the versioned (mike) deploy, since MkDocs
does not rewrite raw <source> URLs.

- Track *.mp4 via Git LFS; drop stale model-file LFS rules
- Remove four unused/duplicate model assets
- Update tourist, annotate_2d_dataset, automatic, and model docs to use
  the video() macro